### PR TITLE
Disable Rack::Cache

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module SupportApi
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.api_only = false
+
+    # Disable Rack::Cache
+    config.action_dispatch.rack_cache = nil
   end
 end


### PR DESCRIPTION
As documented here:

```
https://github.com/alphagov/wiki/wiki/Setting-up-a-new-app#disabling-caching
```

We strongly discourage response caching within applications. Applications should focus on delivering fast responses with appropriate HTTP caching headers which can then be handled appropriately by clients, CDN and dedicated caches above the application layer.
