### PR TITLE
User-agent changes

### DIFF
--- a/db/migrate/20140728110134_change_user_agent_datatype.rb
+++ b/db/migrate/20140728110134_change_user_agent_datatype.rb
@@ -1,0 +1,5 @@
+class ChangeUserAgentDatatype < ActiveRecord::Migration
+  def change
+    change_column :anonymous_contacts, :user_agent, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,9 +1,4 @@
 # encoding: UTF-8
-
-# Note: this file originally comes from the 'support' app, and the master version
-# of the schema is in that app for the moment. The intention is that all persistence
-# will move into this app soon, at which point this app becomes the owner of the schema
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,11 +9,11 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140630065039) do
+ActiveRecord::Schema.define(version: 20140728110134) do
 
-  create_table "anonymous_contacts", :force => true do |t|
+  create_table "anonymous_contacts", force: true do |t|
     t.string   "type"
     t.text     "what_doing"
     t.text     "what_wrong"
@@ -26,16 +21,16 @@ ActiveRecord::Schema.define(:version => 20140630065039) do
     t.string   "source"
     t.string   "page_owner"
     t.text     "url"
-    t.string   "user_agent"
+    t.text     "user_agent"
     t.string   "referrer"
     t.boolean  "javascript_enabled"
-    t.datetime "created_at",                                    :null => false
-    t.datetime "updated_at",                                    :null => false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.string   "personal_information_status"
     t.string   "slug"
     t.integer  "service_satisfaction_rating"
     t.text     "user_specified_url"
-    t.boolean  "is_actionable",               :default => true, :null => false
+    t.boolean  "is_actionable",               default: true, null: false
     t.string   "reason_why_not_actionable"
     t.text     "path"
   end

--- a/lib/support/requests/anonymous/anonymous_contact.rb
+++ b/lib/support/requests/anonymous/anonymous_contact.rb
@@ -10,6 +10,7 @@ module Support
         validates :referrer, url: true, length: { maximum: 2048 }, allow_nil: true
         validates :url,      url: true, length: { maximum: 2048 }, allow_nil: true
         validates :path,     url: true, length: { maximum: 2048 }, allow_nil: true
+        validates :user_agent, length: { maximum: 2048 }
         validates :details, length: { maximum: 2 ** 16 }
         validates_inclusion_of :javascript_enabled, in: [ true, false ]
         validates_inclusion_of :personal_information_status, in: [ "suspected", "absent" ], allow_nil: true


### PR DESCRIPTION
This change allows the user agent to be longer than 255 chars (there are legitimate
user agents that can be longer than that) but caps it with a validation at 2048 (which
matches the `feedback` app).

It looks like this worked before because the `support` app truncated any overrunning
user agents automatically.
