### PR TITLE
Move service feedback perisistence to a worker

### DIFF
--- a/app/controllers/anonymous_feedback/service_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback/service_feedback_controller.rb
@@ -6,8 +6,8 @@ module AnonymousFeedback
       request = Support::Requests::Anonymous::ServiceFeedback.new(service_feedback_params)
 
       if request.valid?
-        request.save!
-        render nothing: true, status: 201
+        ServiceFeedbackWorker.perform_async(service_feedback_params)
+        render nothing: true, status: 202
       else
         render json: { "errors" => request.errors.to_a }, status: 422
       end

--- a/app/workers/service_feedback_worker.rb
+++ b/app/workers/service_feedback_worker.rb
@@ -1,0 +1,9 @@
+require 'support/requests/anonymous/service_feedback'
+
+class ServiceFeedbackWorker
+  include Sidekiq::Worker
+
+  def perform(service_feedback_params)
+    Support::Requests::Anonymous::ServiceFeedback.new(service_feedback_params).save!
+  end
+end

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -65,6 +65,6 @@ describe "Service feedback" do
          { "service_feedback" => options }.to_json,
          {"CONTENT_TYPE" => 'application/json', 'HTTP_ACCEPT' => 'application/json'}
 
-    expect(response.status).to eq(201)
+    expect(response.status).to eq(202)
   end
 end


### PR DESCRIPTION
This allows doing expensive operations (eg organisation lookup
for service feedback) without delaying the form submission on
the frontend, and may result in a slightly quicker response to the frontend app.
