### PR TITLE
Move `whenever` schedule into the app

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,11 @@
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+
+set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+
+# We need Rake to use our own environment
+job_type :rake, "cd :path && govuk_setenv support-api bundle exec rake :task :output"
+
+every 1.day, :at => '12:30 am' do
+  rake "performance_platform_uploads:push_service_feedback"
+end


### PR DESCRIPTION
The schedule isn't secret, nor does it vary across environments, so it should
live together with the app.

https://github.gds/gds/alphagov-deployment/pull/728 should be merged first.
