### PR TITLE
Add problem report totals endpoint

### DIFF
--- a/app/controllers/anonymous_feedback/problem_reports_controller.rb
+++ b/app/controllers/anonymous_feedback/problem_reports_controller.rb
@@ -1,0 +1,19 @@
+module AnonymousFeedback
+  class ProblemReportsController < ApplicationController
+    def totals
+      date = DateTime.parse(params[:date]) rescue nil
+
+      if date.nil?
+        head 404
+      else
+        totals = Support::Requests::Anonymous::ProblemReport.totals_for(date)
+        result = {
+          date: date.to_time.iso8601,
+          data: totals.map { |entry| { path: entry.path, total: entry.total } }
+        }
+
+        render json: result
+      end
+    end
+  end
+end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -6,6 +6,13 @@ module Support
       class ProblemReport < AnonymousContact
         validates :what_doing, length: { maximum: 2 ** 16 }
         validates :what_wrong, length: { maximum: 2 ** 16 }
+
+        scope :totals_for, ->(date) {
+          where(created_at: date.beginning_of_day..date.end_of_day).
+            select("path, count(path) as total").
+            group(:path).
+            order("total desc")
+        }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
               format: false,
               controller: "long_form_contact",
               as: "long_form_contact"
+
+    get '/problem-reports/:date/totals',
+        constraints: { date: /\d{4}-\d{2}-\d{2}/ },
+        to: 'problem_reports#totals'
   end
 
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }

--- a/spec/controllers/anonymous_feedback/problem_reports_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/problem_reports_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+module AnonymousFeedback
+  describe ProblemReportsController do
+    context "#totals" do
+      it "returns a 404 for invalid dates" do
+        get :totals, { date: "9999-99-99" }
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -1,9 +1,12 @@
 require 'support/requests/anonymous/anonymous_contact'
+require 'support/requests/anonymous/problem_report'
 require 'support/requests/anonymous/service_feedback'
 
 FactoryGirl.define do
   factory :anonymous_contact, class: Support::Requests::Anonymous::AnonymousContact do
     javascript_enabled true
+
+    factory :problem_report, class: Support::Requests::Anonymous::ProblemReport
 
     factory :service_feedback, class: Support::Requests::Anonymous::ServiceFeedback do
       path { "/done/#{slug}" }

--- a/spec/requests/problem_reports_spec.rb
+++ b/spec/requests/problem_reports_spec.rb
@@ -1,0 +1,24 @@
+require 'json'
+require 'rails_helper'
+
+describe "Problem reports" do
+  # In order to improve information and services on GOV.UK
+  # As a publisher
+  # I want to record and view bugs, gripes submitted by GOV.UK users
+
+  it "calculates the problem report totals by day" do
+    Timecop.travel Date.new(2013,2,11)
+
+    create(:problem_report, path: "/vat-rates")
+    create(:problem_report, path: "/vat-rates")
+    create(:problem_report, path: "/tax-disc")
+
+    get_json "/anonymous-feedback/problem-reports/2013-02-11/totals"
+
+    expect(response.status).to eq(200)
+    expect(json_response["data"]).to eq([
+      { "path" => "/vat-rates", "total" => 2 },
+      { "path" => "/tax-disc", "total" => 1 },
+    ])
+  end
+end

--- a/spec/support/json_helpers.rb
+++ b/spec/support/json_helpers.rb
@@ -1,0 +1,14 @@
+module JsonHelpers
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  def get_json(url)
+    get url, "", {
+      "CONTENT_TYPE" => 'application/json',
+      'HTTP_ACCEPT' => 'application/json',
+    }
+  end
+end
+
+RSpec.configure { |c| c.include JsonHelpers }


### PR DESCRIPTION
This endpoint allows getting summaries by day, which is useful
because it allows publishers to see which part of the site to focus
on and improve, as well as being consumable for reporting purposes.

Request:

```
GET /anonymous-feedback/problem-reports/2014-09-24/totals
```

Response:

```
{
  date: "2014-09-24T00:00:00+00:00",
  results: [
    {
      "path": "/tax-disc",
      "total": 3
    },
    {
      "path": "/jobmatch",
      "total": 2
    }
  ]
}
```
