### PR TITLE
Bugfix for problem report totals

### DIFF
--- a/app/models/support/requests/anonymous/anonymous_contact.rb
+++ b/app/models/support/requests/anonymous/anonymous_contact.rb
@@ -19,7 +19,10 @@ module Support
         validates_presence_of :reason_why_not_actionable, unless: "is_actionable"
 
         scope :only_actionable, -> { where(is_actionable: true) }
-        default_scope { only_actionable }
+        default_scope {
+          only_actionable.
+          where("path is not null") # this can be removed when path can't be nil
+        }
 
         def self.deduplicate_contacts_created_between(interval)
           contacts = where(created_at: interval).order("created_at asc")

--- a/spec/models/support/requests/anonymous/problem_report_spec.rb
+++ b/spec/models/support/requests/anonymous/problem_report_spec.rb
@@ -14,16 +14,25 @@ module Support
         it { should ensure_length_of(:what_wrong).is_at_most(2**16) }
 
         context "#totals" do
+          let(:result) {
+            ProblemReport.totals_for(Date.today).map { |r| { path: r.path, total: r.total } }
+          }
+
           it "returns totals for a given day" do
             create(:problem_report, path: "/vat-rates")
             create_list(:problem_report, 2, path: "/student-finance-login")
-
-            result = ProblemReport.totals_for(Date.today).map { |r| { path: r.path, total: r.total } }
 
             expect(result).to eq([
               { path: "/student-finance-login", total: 2 },
               { path: "/vat-rates", total: 1 }
             ])
+          end
+
+          it "ignores problem reports with null paths" do # there shouldn't really be any
+            create(:problem_report, path: "/vat-rates")
+            create(:problem_report, path: nil)
+
+            expect(result).to eq([ { path: "/vat-rates", total: 1 } ])
           end
         end
       end


### PR DESCRIPTION
This PR fixes the issue of the problem report daily totals feed returning entries with null paths. Null paths break the upload of the data to the PP.
