### PR TITLE
Better encapsulation of Zendesk

### DIFF
--- a/app/workers/long_form_contact_worker.rb
+++ b/app/workers/long_form_contact_worker.rb
@@ -1,13 +1,10 @@
 require 'support/requests/anonymous/long_form_contact'
-require 'zendesk/long_form_contact_ticket'
 
 class LongFormContactWorker
   include Sidekiq::Worker
 
   def perform(long_form_contact_params)
-    contact = Support::Requests::Anonymous::LongFormContact.new(long_form_contact_params)
-    contact.save!
-    ticket = Zendesk::LongFormContactTicket.new(contact)
-    ZendeskTicketWorker.perform_async(ticket.attributes)
+    contact = Support::Requests::Anonymous::LongFormContact.create!(long_form_contact_params)
+    ZendeskTicketWorker.perform_async(contact.id)
   end
 end

--- a/app/workers/problem_report_worker.rb
+++ b/app/workers/problem_report_worker.rb
@@ -1,13 +1,10 @@
 require 'support/requests/anonymous/problem_report'
-require 'zendesk/problem_report_ticket'
 
 class ProblemReportWorker
   include Sidekiq::Worker
 
   def perform(problem_report_params)
-    problem_report = Support::Requests::Anonymous::ProblemReport.new(problem_report_params)
-    problem_report.save!
-    ticket = Zendesk::ProblemReportTicket.new(problem_report)
-    ZendeskTicketWorker.perform_async(ticket.attributes)
+    problem_report = Support::Requests::Anonymous::ProblemReport.create!(problem_report_params)
+    ZendeskTicketWorker.perform_async(problem_report.id)
   end
 end

--- a/app/workers/zendesk_ticket_worker.rb
+++ b/app/workers/zendesk_ticket_worker.rb
@@ -1,7 +1,21 @@
+require 'zendesk/long_form_contact_ticket'
+require 'zendesk/problem_report_ticket'
+
 class ZendeskTicketWorker
   include Sidekiq::Worker
+  include Support::Requests::Anonymous
 
-  def perform(ticket_attributes)
+  def perform(anonymous_contact_id)
+    anonymous_contact = AnonymousContact.find(anonymous_contact_id)
+    ticket_attributes = ticket_for(anonymous_contact).attributes
     GDS_ZENDESK_CLIENT.ticket.create!(HashWithIndifferentAccess.new(ticket_attributes))
+  end
+
+private
+  def ticket_for(anonymous_contact)
+    case anonymous_contact
+    when LongFormContact then Zendesk::LongFormContactTicket.new(anonymous_contact)
+    when ProblemReport then Zendesk::ProblemReportTicket.new(anonymous_contact)
+    end
   end
 end


### PR DESCRIPTION
This change moves all Zendesk-related logic for anonymous feedback to
the ZendeskTicketWorker, rather than the logic being sprinkled across
several classes.