### PR TITLE
Identify content items, organisations for each problem report

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,0 +1,3 @@
+class ContentItem < ActiveRecord::Base
+  validates :path, presence: true
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,3 +1,11 @@
 class ContentItem < ActiveRecord::Base
+  has_and_belongs_to_many :organisations
   validates :path, presence: true
+
+  before_create :fetch_organisations
+
+  private
+  def fetch_organisations
+    self.organisations = Organisation.for_path(path)
+  end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,7 +1,14 @@
+require 'content_api/enhanced_content_api'
+
 class Organisation < ActiveRecord::Base
   has_and_belongs_to_many :content_items
 
   validates :slug, presence: true
   validates :web_url, presence: true
   validates :title, presence: true
+
+  def self.for_path(path)
+    orgs_data = SupportApi::enhanced_content_api.organisations_for(path)
+    orgs_data.map {|org_info| Organisation.where(org_info).first_or_create! }
+  end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,7 @@
+class Organisation < ActiveRecord::Base
+  has_and_belongs_to_many :content_items
+
+  validates :slug, presence: true
+  validates :web_url, presence: true
+  validates :title, presence: true
+end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -1,4 +1,5 @@
 require 'support/requests/anonymous/anonymous_contact'
+require 'content_api/enhanced_content_api'
 
 module Support
   module Requests
@@ -15,6 +16,10 @@ module Support
             group(:path).
             order("total desc")
         }
+
+        def content_item_path
+          SupportApi::enhanced_content_api.content_item_path(path)
+        end
       end
     end
   end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -7,6 +7,8 @@ module Support
         validates :what_doing, length: { maximum: 2 ** 16 }
         validates :what_wrong, length: { maximum: 2 ** 16 }
 
+        belongs_to :content_item
+
         scope :totals_for, ->(date) {
           where(created_at: date.beginning_of_day..date.end_of_day).
             select("path, count(path) as total").

--- a/app/workers/content_item_enrichment_worker.rb
+++ b/app/workers/content_item_enrichment_worker.rb
@@ -1,0 +1,9 @@
+class ContentItemEnrichmentWorker
+  include Sidekiq::Worker
+
+  def perform(problem_report_id)
+    problem_report = Support::Requests::Anonymous::ProblemReport.find(problem_report_id)
+    problem_report.content_item = ContentItem.where(path: problem_report.content_item_path).first_or_create!
+    problem_report.save!
+  end
+end

--- a/app/workers/problem_report_worker.rb
+++ b/app/workers/problem_report_worker.rb
@@ -6,5 +6,6 @@ class ProblemReportWorker
   def perform(problem_report_params)
     problem_report = Support::Requests::Anonymous::ProblemReport.create!(problem_report_params)
     ZendeskTicketWorker.perform_async(problem_report.id)
+    ContentItemEnrichmentWorker.perform_async(problem_report.id)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ Bundler.require(*Rails.groups)
 
 module SupportApi
   class Application < Rails::Application
+    require "support_api"
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -1,0 +1,6 @@
+require 'plek'
+require 'gds_api/content_api'
+require 'content_api/enhanced_content_api'
+
+content_api = GdsApi::ContentApi.new(Plek.find('contentapi'))
+SupportApi.enhanced_content_api = ContentAPI::EnhancedContentAPI.new(content_api)

--- a/db/migrate/20141230121133_add_content_items_and_organisations.rb
+++ b/db/migrate/20141230121133_add_content_items_and_organisations.rb
@@ -1,0 +1,22 @@
+class AddContentItemsAndOrganisations < ActiveRecord::Migration
+  def change
+    create_table :content_items do |t|
+      t.string "path", limit: 2048, null: false
+      t.timestamps null: false
+    end
+
+    create_table :organisations do |t|
+      t.string :slug, null: false
+      t.string :web_url, null: false
+      t.string :title, null: false
+      t.timestamps null: false
+    end
+
+    create_table :content_items_organisations, id: false do |t|
+      t.belongs_to :content_item, index: true
+      t.belongs_to :organisation, index: true
+    end
+
+    add_column :anonymous_contacts, :content_item_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141002165103) do
+ActiveRecord::Schema.define(version: 20141230121133) do
 
   create_table "anonymous_contacts", force: true do |t|
     t.string   "type"
@@ -33,6 +33,29 @@ ActiveRecord::Schema.define(version: 20141002165103) do
     t.boolean  "is_actionable",                            default: true, null: false
     t.string   "reason_why_not_actionable"
     t.string   "path",                        limit: 2048
+    t.integer  "content_item_id"
+  end
+
+  create_table "content_items", force: true do |t|
+    t.string   "path",       limit: 2048, null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  create_table "content_items_organisations", id: false, force: true do |t|
+    t.integer "content_item_id"
+    t.integer "organisation_id"
+  end
+
+  add_index "content_items_organisations", ["content_item_id"], name: "index_content_items_organisations_on_content_item_id", using: :btree
+  add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
+
+  create_table "organisations", force: true do |t|
+    t.string   "slug",       null: false
+    t.string   "web_url",    null: false
+    t.string   "title",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/lib/content_api/base_info_lookup.rb
+++ b/lib/content_api/base_info_lookup.rb
@@ -1,0 +1,36 @@
+module ContentAPI
+  class BaseInfoLookup
+    def initialize(content_api)
+      @content_api = content_api
+    end
+
+    def applies?(path)
+      false
+    end
+
+    def organisations_for(path)
+      path = content_item_api_path(path)
+      response = api_response(path)
+
+      if response && response["tags"]
+        orgs_from_tags(response["tags"])
+      else
+        []
+      end
+    end
+
+    private
+    def content_item_api_path(path)
+      raise "should be implemented in the subclass"
+    end
+
+    def orgs_from_tags(tags)
+      org_tags = tags.select {|t| t["details"]["type"] == "organisation" }
+      org_tags.map { |tag| { slug: tag["slug"], web_url: tag["web_url"], title: tag["title"] } }
+    end
+
+    def api_response(api_path)
+      @content_api.artefact(api_path)
+    end
+  end
+end

--- a/lib/content_api/depts_and_policy_content_lookup.rb
+++ b/lib/content_api/depts_and_policy_content_lookup.rb
@@ -1,0 +1,21 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class DeptsAndPolicyContentLookup < BaseInfoLookup
+    def applies?(path)
+      path =~ %r{^/government/} && path !~ %r{^/government/organisations}
+    end
+
+    def content_item_api_path(path)
+      content_item_path(path)
+    end
+
+    def content_item_path(path)
+      # to handle sub-pages that belong to a particular document (eg an HTML publication)
+      # eg /government/publications/customer-service-commitments-uk-visas-and-immigration/uk-visas-and-immigration-customer-commitments
+      # the path is stripped back to the parent page
+      # (in the example, this is /government/publications/customer-service-commitments-uk-visas-and-immigration)
+      URI(path).path.split("/")[0..3].join("/")
+    end
+  end
+end

--- a/lib/content_api/enhanced_content_api.rb
+++ b/lib/content_api/enhanced_content_api.rb
@@ -1,0 +1,35 @@
+require 'uri'
+
+require 'content_api/depts_and_policy_content_lookup'
+require 'content_api/gds_owned_content_lookup'
+require 'content_api/mainstream_info_lookup'
+require 'content_api/orgs_content_lookup'
+require 'content_api/worldwide_orgs_content_lookup'
+
+module ContentAPI
+  class EnhancedContentAPI
+    def initialize(content_api)
+      @lookups = [
+        GDSOwnedContentLookup.new,
+        MainstreamInfoLookup.new(content_api),
+        OrgsContentLookup.new(content_api),
+        WorldwideOrgsContentLookup.new,
+        DeptsAndPolicyContentLookup.new(content_api),
+      ]
+    end
+
+    def organisations_for(path)
+      applicable_lookups = @lookups.select { |lookup| lookup.applies?(path) }
+      applicable_lookups.each do |lookup|
+        orgs = lookup.organisations_for(path)
+        return orgs unless orgs.empty?
+      end
+      nil
+    end
+
+    def content_item_path(path)
+      lookup = @lookups.detect { |lookup| lookup.applies?(path) }
+      lookup.content_item_path(path)
+    end
+  end
+end

--- a/lib/content_api/gds_owned_content_lookup.rb
+++ b/lib/content_api/gds_owned_content_lookup.rb
@@ -1,0 +1,21 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class GDSOwnedContentLookup
+    def applies?(path)
+      path =~ %r{(^/browse|^/contact($|/)|^/search|^/help($|/))}
+    end
+
+    def organisations_for(path)
+      [{
+        slug: "government-digital-service",
+        web_url: "https://www.gov.uk/government/organisations/government-digital-service",
+        title: "Government Digital Service",
+      }]
+    end
+
+    def content_item_path(path)
+      path
+    end
+  end
+end

--- a/lib/content_api/mainstream_info_lookup.rb
+++ b/lib/content_api/mainstream_info_lookup.rb
@@ -1,0 +1,17 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class MainstreamInfoLookup < BaseInfoLookup
+    def applies?(path)
+      path !~ %r{^/government/}
+    end
+
+    def content_item_api_path(path)
+      content_item_path(path)
+    end
+
+    def content_item_path(path)
+      "/" + path.split("/")[1]
+    end
+  end
+end

--- a/lib/content_api/orgs_content_lookup.rb
+++ b/lib/content_api/orgs_content_lookup.rb
@@ -1,0 +1,32 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class OrgsContentLookup < BaseInfoLookup
+    def applies?(path)
+      path =~ %r{^/government/organisations}
+    end
+
+    def organisations_for(path)
+      api_path = content_item_api_path(path)
+      response = api_response(api_path)
+
+      if response && response["details"]
+        [{
+          slug: response["details"]["slug"],
+          web_url: response["web_url"],
+          title: response["title"],
+        }]
+      else
+        []
+      end
+    end
+
+    def content_item_path(path)
+      "/" + URI(path).path.split("/")[1..3].join("/")
+    end
+
+    def content_item_api_path(path)
+      "/" + URI(path).path.split("/")[2..3].join("/")
+    end
+  end
+end

--- a/lib/content_api/worldwide_orgs_content_lookup.rb
+++ b/lib/content_api/worldwide_orgs_content_lookup.rb
@@ -1,0 +1,36 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class WorldwideOrgsContentLookup
+    def applies?(path)
+      path =~ %r{^/government/world/organisations}
+    end
+
+    def organisations_for(path)
+      case path
+      when /dfid/ then
+        [{
+          slug: "department-for-international-development",
+          web_url: "https://www.gov.uk/government/organisations/department-for-international-development",
+          title: "Department for International Development",
+        }]
+      when /uk-trade-investment/ then
+        [{
+          slug: "uk-trade-investment",
+          web_url: "https://www.gov.uk/government/organisations/uk-trade-investment",
+          title: "UK Trade & Investment",
+        }]
+      else
+        [{
+          slug: "foreign-commonwealth-office",
+          web_url: "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
+          title: "Foreign & Commonwealth Office",
+        }]
+      end
+    end
+
+    def content_item_path(path)
+      path
+    end
+  end
+end

--- a/lib/support_api.rb
+++ b/lib/support_api.rb
@@ -1,0 +1,3 @@
+module SupportApi
+  mattr_accessor :enhanced_content_api
+end

--- a/spec/models/content_api/enhanced_content_api_spec.rb
+++ b/spec/models/content_api/enhanced_content_api_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+require 'content_api/enhanced_content_api'
+require 'plek'
+require 'gds_api/test_helpers/content_api'
+require 'gds_api/content_api'
+
+module ContentAPI
+  describe EnhancedContentAPI do
+    include GdsApi::TestHelpers::ContentApi
+
+    let(:content_api) { GdsApi::ContentApi.new(Plek.find('contentapi')) }
+    subject(:api) { EnhancedContentAPI.new(content_api) }
+
+    context "mapping multi-page content to slugs" do
+      it "maps mainstream guide sections to the guide root" do
+        mappings = {
+          [ "/contact-ukvi", "/contact-ukvi/overview" ] => "/contact-ukvi",
+          [ "/tax-disc"] => "/tax-disc",
+          [ "/check-uk-visa/y", "/check-uk-visa" ] => "/check-uk-visa",
+          [
+            "/government/organisations/hm-revenue-customs",
+            "/government/organisations/hm-revenue-customs/contact/corporation-tax-enquiries",
+            "/government/organisations/hm-revenue-customs/services-information",
+          ] => "/government/organisations/hm-revenue-customs",
+          [
+            "/government/publications/govuk-proposition",
+            "/government/publications/govuk-proposition/govuk-proposition",
+          ] => "/government/publications/govuk-proposition",
+          [ "/contact" ] => "/contact",
+          [ "/contact/govuk" ] => "/contact/govuk",
+          [ "/search" ] => "/search",
+          [ "/browse/driving" ] => "/browse/driving",
+          [ "/browse/driving/blue-badge-parking" ] => "/browse/driving/blue-badge-parking",
+        }
+
+        mappings.each do |source_paths, content_item_path|
+          source_paths.each { |source_path| expect(api.content_item_path(source_path)).to eq(content_item_path) }
+        end
+      end
+    end
+
+    context "organisation lookup" do
+      let(:default_content_api_response) {
+        {
+          tags: [
+            {
+              id: "https://www.gov.uk/api/tags/organisation/uk-visas-and-immigration.json",
+              slug: "uk-visas-and-immigration",
+              web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
+              title: "UK Visas and Immigration",
+              details: {
+                type: "organisation"
+              },
+            },
+          ]
+        }
+      }
+
+      let(:gds_org_info) {
+        {
+          slug: "government-digital-service",
+          web_url: "https://www.gov.uk/government/organisations/government-digital-service",
+          title: "Government Digital Service",
+        }
+      }
+
+      context "(mainstream content)" do
+        it "fetches the organisations" do
+          content_api_has_an_artefact("/contact-ukvi", default_content_api_response)
+
+          expect(api.organisations_for("/contact-ukvi/overview")).to eq([
+            slug: "uk-visas-and-immigration",
+            web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
+            title: "UK Visas and Immigration",
+          ])
+        end
+      end
+
+      context "(Depts & Policy content)" do
+        it "fetches the organisations" do
+          content_api_has_an_artefact(
+            "/government/publications/customer-service-commitments-uk-visas-and-immigration",
+            default_content_api_response
+          )
+
+          expect(api.organisations_for("/government/publications/customer-service-commitments-uk-visas-and-immigration")).to eq([
+            slug: "uk-visas-and-immigration",
+            web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
+            title: "UK Visas and Immigration",
+          ])
+        end
+      end
+
+      context "(GDS-owned pages)" do
+        it "should have GDS as the owning org" do
+          [ "/help", "/help/beta", "/contact", "/contact/govuk", "/search", "/browse", "/browse/driving" ].each do |gds_owned_path|
+            expect(api.organisations_for(gds_owned_path)).to eq([gds_org_info])
+          end
+        end
+      end
+
+      context "(organisation pages)" do
+        let(:hmrc_info) {
+          {
+            slug: "hm-revenue-customs",
+            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+            title: "HM Revenue & Customs",
+          }
+        }
+
+        let(:hmrc_org_content_api_response) {
+          {
+            id: "https://www.gov.uk/api/organisations/hm-revenue-customs",
+            title: "HM Revenue & Customs",
+            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+            details: {
+              slug: "hm-revenue-customs",
+            },
+          }
+        }
+
+        it "should be attributed to that org" do
+          content_api_has_an_artefact("/organisations/hm-revenue-customs", hmrc_org_content_api_response)
+
+          [
+            "/government/organisations/hm-revenue-customs",
+            "/government/organisations/hm-revenue-customs/contact/corporation-tax-enquiries",
+            "/government/organisations/hm-revenue-customs/services-information",
+          ].each do |hmrc_path|
+            expect(api.organisations_for(hmrc_path)).to eq([hmrc_info])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to present relevant anonymous feedback to users in departments and ALBs, we need to know which organisation is interested in a particular piece of feedback. This can be done by looking up at the orgs that relate to the piece of content that originated the problem report.

The org information is retrieved from the Content API and persisted; this saves having to fetch a list of all content relating to a particular org, and trying to get the feedback for each one of those paths.

More details about the implementation in the commit messages.
