### PR TITLE
Content identification fixes

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,7 +8,7 @@ class Organisation < ActiveRecord::Base
   validates :title, presence: true
 
   def self.for_path(path)
-    orgs_data = SupportApi::enhanced_content_api.organisations_for(path)
+    orgs_data = SupportApi::enhanced_content_api.organisations_for(path) || []
     orgs_data.map {|org_info| Organisation.where(org_info).first_or_create! }
   end
 end

--- a/lib/content_api/base_info_lookup.rb
+++ b/lib/content_api/base_info_lookup.rb
@@ -30,7 +30,8 @@ module ContentAPI
     end
 
     def api_response(api_path)
-      @content_api.artefact(api_path)
+      slug = api_path[1..-1] # the content API expects "vat-rates" instead of "/vat-rates"
+      @content_api.artefact(slug)
     end
   end
 end

--- a/spec/models/content_api/enhanced_content_api_spec.rb
+++ b/spec/models/content_api/enhanced_content_api_spec.rb
@@ -66,7 +66,7 @@ module ContentAPI
 
       context "(mainstream content)" do
         it "fetches the organisations" do
-          content_api_has_an_artefact("/contact-ukvi", default_content_api_response)
+          content_api_has_an_artefact("contact-ukvi", default_content_api_response)
 
           expect(api.organisations_for("/contact-ukvi/overview")).to eq([
             slug: "uk-visas-and-immigration",
@@ -79,7 +79,7 @@ module ContentAPI
       context "(Depts & Policy content)" do
         it "fetches the organisations" do
           content_api_has_an_artefact(
-            "/government/publications/customer-service-commitments-uk-visas-and-immigration",
+            "government/publications/customer-service-commitments-uk-visas-and-immigration",
             default_content_api_response
           )
 
@@ -120,7 +120,7 @@ module ContentAPI
         }
 
         it "should be attributed to that org" do
-          content_api_has_an_artefact("/organisations/hm-revenue-customs", hmrc_org_content_api_response)
+          content_api_has_an_artefact("organisations/hm-revenue-customs", hmrc_org_content_api_response)
 
           [
             "/government/organisations/hm-revenue-customs",

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_api'
+
+describe ContentItemEnrichmentWorker do
+  include GdsApi::TestHelpers::ContentApi
+
+  subject { ContentItemEnrichmentWorker.new }
+
+  context "for a problem report that relates to a non-existent piece of content" do
+    let(:problem_report) { create(:problem_report, path: "/non-existent-page") }
+
+    before do
+      content_api_does_not_have_an_artefact("non-existent-page")
+      subject.perform(problem_report.id)
+      problem_report.reload
+    end
+
+    it "creates a content item for the problem report, but no orgs" do
+      expect(problem_report.content_item.path).to eq("/non-existent-page")
+      expect(problem_report.content_item.organisations).to be_empty
+    end
+  end
+
+  context "for a problem report that relates to a piece of mainstream content" do
+    let(:hmrc) { Organisation.where(slug: 'hm-revenue-customs').first }
+    let(:vat_rates_content_api_response) {
+      api_response = artefact_for_slug("vat-rates").tap do |hash|
+        hash["tags"] = [
+          {
+            slug: "hm-revenue-customs",
+            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+            title: "HM Revenue & Customs",
+            details: {
+              type: "organisation",
+            }
+          }
+        ]
+      end
+    }
+
+    let(:problem_report) { create(:problem_report, path: "/vat-rates") }
+
+    before do
+      content_api_has_an_artefact("vat-rates", vat_rates_content_api_response)
+      subject.perform(problem_report.id)
+      problem_report.reload
+    end
+
+    it "creates a content item for the problem report, but no orgs" do
+      expect(problem_report.content_item.path).to eq("/vat-rates")
+      expect(problem_report.content_item.organisations).to eq([hmrc])
+    end
+  end
+end

--- a/spec/requests/problem_reports_spec.rb
+++ b/spec/requests/problem_reports_spec.rb
@@ -12,7 +12,7 @@ describe "Problem reports" do
 
   let(:hmrc) { Organisation.where(slug: 'hm-revenue-customs').first }
   let(:vat_rates_content_api_response) {
-    api_response = artefact_for_slug("/vat-rates").tap do |hash|
+    api_response = artefact_for_slug("vat-rates").tap do |hash|
       hash["tags"] = [
         {
           slug: "hm-revenue-customs",
@@ -43,7 +43,7 @@ describe "Problem reports" do
   end
 
   it "accepts and saves problem reports from the 'Is there anything wrong with this page?' form" do
-    content_api_has_an_artefact("/vat-rates", vat_rates_content_api_response)
+    content_api_has_an_artefact("vat-rates", vat_rates_content_api_response)
 
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "/vat-rates",


### PR DESCRIPTION
This is a follow-PR to #26. It contains hardening of the feature and fixes issues found during testing on Preview:

- incorrect parameters being passed to the Content API
- handle the case when the Content API returns 404 for a slug
- bolster test coverage around problem report enrichment