### PR TITLE
Bump rails-api to v0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.0'
-gem 'rails-api', '0.3.1'
+gem 'rails-api', '0.4.0'
 gem 'mysql2', '0.3.16'
 gem 'logstasher', '0.6.2'
 gem 'airbrake', '4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.0)
       sprockets-rails
-    rails-api (0.3.1)
+    rails-api (0.4.0)
       actionpack (>= 3.2.11)
       railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)
@@ -237,7 +237,7 @@ DEPENDENCIES
   mysql2 (= 0.3.16)
   plek (= 1.9.0)
   rails (= 4.2.0)
-  rails-api (= 0.3.1)
+  rails-api (= 0.4.0)
   rspec-collection_matchers (= 1.1.2)
   rspec-rails (= 3.1.0)
   shoulda-matchers (= 2.7.0)


### PR DESCRIPTION
This fixes the deprecation warning that started appearing after the upgrade to rails 4.2.0.