### PR TITLE
Fix the org lookup for organisation pages

### DIFF
--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -1,6 +1,9 @@
 require 'plek'
 require 'gds_api/content_api'
+require 'gds_api/content_store'
+require 'gds_api/organisations'
 require 'content_api/enhanced_content_api'
 
 content_api = GdsApi::ContentApi.new(Plek.find('contentapi'))
-SupportApi.enhanced_content_api = ContentAPI::EnhancedContentAPI.new(content_api)
+content_store = GdsApi::ContentStore.new(Plek.find('content-store'))
+SupportApi.enhanced_content_api = ContentAPI::EnhancedContentAPI.new(content_api, content_store)

--- a/lib/content_api/enhanced_content_api.rb
+++ b/lib/content_api/enhanced_content_api.rb
@@ -8,11 +8,11 @@ require 'content_api/worldwide_orgs_content_lookup'
 
 module ContentAPI
   class EnhancedContentAPI
-    def initialize(content_api)
+    def initialize(content_api, organisations_api)
       @lookups = [
         GDSOwnedContentLookup.new,
         MainstreamInfoLookup.new(content_api),
-        OrgsContentLookup.new(content_api),
+        OrgsContentLookup.new(organisations_api),
         WorldwideOrgsContentLookup.new,
         DeptsAndPolicyContentLookup.new(content_api),
       ]

--- a/lib/content_api/orgs_content_lookup.rb
+++ b/lib/content_api/orgs_content_lookup.rb
@@ -1,19 +1,23 @@
 require 'content_api/base_info_lookup'
 
 module ContentAPI
-  class OrgsContentLookup < BaseInfoLookup
+  class OrgsContentLookup
+    def initialize(content_store)
+      @content_store = content_store
+    end
+
     def applies?(path)
-      path =~ %r{^/government/organisations}
+      path =~ %r{^/government/organisations/.+}
     end
 
     def organisations_for(path)
-      api_path = content_item_api_path(path)
-      response = api_response(api_path)
+      path_to_lookup = content_item_path(path)
+      response = @content_store.content_item(path_to_lookup)
 
-      if response && response["details"]
+      if response
         [{
-          slug: response["details"]["slug"],
-          web_url: response["web_url"],
+          slug: organisation_slug(path),
+          web_url: Plek.new.website_root + response["base_path"],
           title: response["title"],
         }]
       else
@@ -22,11 +26,12 @@ module ContentAPI
     end
 
     def content_item_path(path)
-      "/" + URI(path).path.split("/")[1..3].join("/")
+      URI(path).path.split("/")[0..3].join("/")
     end
 
-    def content_item_api_path(path)
-      "/" + URI(path).path.split("/")[2..3].join("/")
+    private
+    def organisation_slug(path)
+      URI(path).path.split("/")[3]
     end
   end
 end

--- a/spec/models/content_api/enhanced_content_api_spec.rb
+++ b/spec/models/content_api/enhanced_content_api_spec.rb
@@ -1,15 +1,18 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'content_api/enhanced_content_api'
 require 'plek'
 require 'gds_api/test_helpers/content_api'
+require 'gds_api/test_helpers/content_store'
 require 'gds_api/content_api'
 
 module ContentAPI
   describe EnhancedContentAPI do
     include GdsApi::TestHelpers::ContentApi
+    include GdsApi::TestHelpers::ContentStore
 
     let(:content_api) { GdsApi::ContentApi.new(Plek.find('contentapi')) }
-    subject(:api) { EnhancedContentAPI.new(content_api) }
+    let(:content_store) { GdsApi::ContentStore.new(Plek.find('content-store')) }
+    subject(:api) { EnhancedContentAPI.new(content_api, content_store) }
 
     context "mapping multi-page content to slugs" do
       it "maps mainstream guide sections to the guide root" do
@@ -103,24 +106,20 @@ module ContentAPI
         let(:hmrc_info) {
           {
             slug: "hm-revenue-customs",
-            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+            web_url: "http://www.dev.gov.uk/government/organisations/hm-revenue-customs",
             title: "HM Revenue & Customs",
           }
         }
 
-        let(:hmrc_org_content_api_response) {
+        let(:hmrc_org_content_store_response) {
           {
-            id: "https://www.gov.uk/api/organisations/hm-revenue-customs",
+            base_path: "/government/organisations/hm-revenue-customs",
             title: "HM Revenue & Customs",
-            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
-            details: {
-              slug: "hm-revenue-customs",
-            },
           }
         }
 
         it "should be attributed to that org" do
-          content_api_has_an_artefact("organisations/hm-revenue-customs", hmrc_org_content_api_response)
+          content_store_has_item("/government/organisations/hm-revenue-customs", hmrc_org_content_store_response)
 
           [
             "/government/organisations/hm-revenue-customs",


### PR DESCRIPTION
Before this change, the code made the false assumption that organisation
info can be found in the Content API. After this change, org info is fetched
from the Content Store.