### PR TITLE
Handle problem reports raised on the homepage

### DIFF
--- a/lib/content_api/gds_owned_content_lookup.rb
+++ b/lib/content_api/gds_owned_content_lookup.rb
@@ -3,7 +3,7 @@ require 'content_api/base_info_lookup'
 module ContentAPI
   class GDSOwnedContentLookup
     def applies?(path)
-      path =~ %r{(^/browse|^/contact($|/)|^/search|^/help($|/))}
+      path =~ %r{(^/$|^/browse|^/contact($|/)|^/search|^/help($|/))}
     end
 
     def organisations_for(path)

--- a/spec/models/content_api/enhanced_content_api_spec.rb
+++ b/spec/models/content_api/enhanced_content_api_spec.rb
@@ -96,7 +96,7 @@ module ContentAPI
 
       context "(GDS-owned pages)" do
         it "should have GDS as the owning org" do
-          [ "/help", "/help/beta", "/contact", "/contact/govuk", "/search", "/browse", "/browse/driving" ].each do |gds_owned_path|
+          [ "/", "/help", "/help/beta", "/contact", "/contact/govuk", "/search", "/browse", "/browse/driving" ].each do |gds_owned_path|
             expect(api.organisations_for(gds_owned_path)).to eq([gds_org_info])
           end
         end


### PR DESCRIPTION
A couple of days ago, the report-a-problem form was added to the homepage
(https://www.gov.uk). This commit enables the organisation-identification
code to handle those problem reports without throwing an exception.

Trigger for this: https://errbit.production.alphagov.co.uk/apps/53be43010da11516ee0007a7/problems/54ca667e0da1156623002322