### PR TITLE
Remove low-quality single-word feedback from the Contacts DB

### DIFF
--- a/db/migrate/20150313183713_remove_low_quality_single_word_feedback.rb
+++ b/db/migrate/20150313183713_remove_low_quality_single_word_feedback.rb
@@ -1,0 +1,13 @@
+class RemoveLowQualitySingleWordFeedback < ActiveRecord::Migration
+  class Support::Requests::Anonymous::ProblemReport; end
+
+  def up
+    Support::Requests::Anonymous::ProblemReport.
+      where.not("what_doing like '% %'").
+      where.not("what_wrong like '% %'").
+      update_all("is_actionable = '0', reason_why_not_actionable = 'low-quality single-word feedback'")
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150115215320) do
+ActiveRecord::Schema.define(version: 20150313183713) do
 
   create_table "anonymous_contacts", force: true do |t|
     t.string   "type"


### PR DESCRIPTION
This feedback has been analysed and shown to be almost never actionable.
