### PR TITLE
Upgrade schema to be compatible with the Rails 4.2.X schema dumper

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,26 +14,26 @@
 ActiveRecord::Schema.define(version: 20150313183713) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
-    t.string   "type"
-    t.text     "what_doing"
-    t.text     "what_wrong"
-    t.text     "details"
-    t.string   "source"
-    t.string   "page_owner"
-    t.text     "url"
-    t.text     "user_agent"
+    t.string   "type",                        limit: 255
+    t.text     "what_doing",                  limit: 65535
+    t.text     "what_wrong",                  limit: 65535
+    t.text     "details",                     limit: 65535
+    t.string   "source",                      limit: 255
+    t.string   "page_owner",                  limit: 255
+    t.text     "url",                         limit: 65535
+    t.text     "user_agent",                  limit: 65535
     t.string   "referrer",                    limit: 2048
-    t.boolean  "javascript_enabled"
-    t.datetime "created_at",                                              null: false
-    t.datetime "updated_at",                                              null: false
-    t.string   "personal_information_status"
-    t.string   "slug"
-    t.integer  "service_satisfaction_rating"
-    t.text     "user_specified_url"
-    t.boolean  "is_actionable",                            default: true, null: false
-    t.string   "reason_why_not_actionable"
+    t.boolean  "javascript_enabled",          limit: 1
+    t.datetime "created_at",                                               null: false
+    t.datetime "updated_at",                                               null: false
+    t.string   "personal_information_status", limit: 255
+    t.string   "slug",                        limit: 255
+    t.integer  "service_satisfaction_rating", limit: 4
+    t.text     "user_specified_url",          limit: 65535
+    t.boolean  "is_actionable",               limit: 1,     default: true, null: false
+    t.string   "reason_why_not_actionable",   limit: 255
     t.string   "path",                        limit: 2048
-    t.integer  "content_item_id"
+    t.integer  "content_item_id",             limit: 4
   end
 
   add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>255}, using: :btree
@@ -45,19 +45,19 @@ ActiveRecord::Schema.define(version: 20150313183713) do
   end
 
   create_table "content_items_organisations", id: false, force: :cascade do |t|
-    t.integer "content_item_id"
-    t.integer "organisation_id"
+    t.integer "content_item_id", limit: 4
+    t.integer "organisation_id", limit: 4
   end
 
   add_index "content_items_organisations", ["content_item_id"], name: "index_content_items_organisations_on_content_item_id", using: :btree
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
   create_table "organisations", force: :cascade do |t|
-    t.string   "slug",       null: false
-    t.string   "web_url",    null: false
-    t.string   "title",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "slug",       limit: 255, null: false
+    t.string   "web_url",    limit: 255, null: false
+    t.string   "title",      limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20150313183713) do
 
-  create_table "anonymous_contacts", force: true do |t|
+  create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type"
     t.text     "what_doing"
     t.text     "what_wrong"
@@ -38,13 +38,13 @@ ActiveRecord::Schema.define(version: 20150313183713) do
 
   add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>255}, using: :btree
 
-  create_table "content_items", force: true do |t|
+  create_table "content_items", force: :cascade do |t|
     t.string   "path",       limit: 2048, null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
 
-  create_table "content_items_organisations", id: false, force: true do |t|
+  create_table "content_items_organisations", id: false, force: :cascade do |t|
     t.integer "content_item_id"
     t.integer "organisation_id"
   end
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20150313183713) do
   add_index "content_items_organisations", ["content_item_id"], name: "index_content_items_organisations_on_content_item_id", using: :btree
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
-  create_table "organisations", force: true do |t|
+  create_table "organisations", force: :cascade do |t|
     t.string   "slug",       null: false
     t.string   "web_url",    null: false
     t.string   "title",      null: false


### PR DESCRIPTION
The ActiveRecord schema dumper has changed between Rails 4.1.X and 4.2.X. This PR brings the `schema.rb` in line with the new behaviour, so that any schema changes in subsequent migrations are minimised. See the individual commits for more details.

/cc @mikejustdoit 