### PR TITLE
Bugfix: fixed NoMethod Error bugs

### DIFF
--- a/lib/content_api/default_org_content_lookup.rb
+++ b/lib/content_api/default_org_content_lookup.rb
@@ -1,0 +1,21 @@
+require 'content_api/base_info_lookup'
+
+module ContentAPI
+  class DefaultOrgContentLookup
+    def applies?(path)
+      true
+    end
+
+    def organisations_for(path)
+      [{
+        slug: "government-digital-service",
+        web_url: "https://www.gov.uk/government/organisations/government-digital-service",
+        title: "Government Digital Service",
+      }]
+    end
+
+    def content_item_path(path)
+      path
+    end
+  end
+end

--- a/lib/content_api/enhanced_content_api.rb
+++ b/lib/content_api/enhanced_content_api.rb
@@ -5,6 +5,7 @@ require 'content_api/gds_owned_content_lookup'
 require 'content_api/mainstream_info_lookup'
 require 'content_api/orgs_content_lookup'
 require 'content_api/worldwide_orgs_content_lookup'
+require 'content_api/default_org_content_lookup'
 
 module ContentAPI
   class EnhancedContentAPI
@@ -15,6 +16,7 @@ module ContentAPI
         OrgsContentLookup.new(organisations_api),
         WorldwideOrgsContentLookup.new,
         DeptsAndPolicyContentLookup.new(content_api),
+        DefaultOrgContentLookup.new
       ]
     end
 

--- a/spec/models/content_api/enhanced_content_api_spec.rb
+++ b/spec/models/content_api/enhanced_content_api_spec.rb
@@ -130,6 +130,19 @@ module ContentAPI
           end
         end
       end
+
+      context "(APIs do not return anything)" do
+        before do
+          content_api_does_not_have_an_artefact("non-existent-page")
+          content_api_does_not_have_an_artefact("page-not-found")
+        end
+
+        it "should be attributed to GDS" do
+          ["/non-existent-page", "/page-not-found"].each do |gds_owned_path|
+            expect(api.organisations_for(gds_owned_path)).to eq([gds_org_info])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -17,7 +17,7 @@ describe ContentItemEnrichmentWorker do
 
     it "creates a content item for the problem report, but no orgs" do
       expect(problem_report.content_item.path).to eq("/non-existent-page")
-      expect(problem_report.content_item.organisations).to be_empty
+      expect(problem_report.content_item.organisations.first["title"]).to eq("Government Digital Service")
     end
   end
 


### PR DESCRIPTION
The support-api was raising regular exceptions in
Errbit:`NoMethodError: undefined method 'content_item_path' for nil:NilClass`

Wrote a test to recreate the bug, fixed it by adding a default org lookup
which will assign to GDS any content items that could not be associated with
another organisation.

cc @benilovj
[Taiga story](https://tree.taiga.io/project/core-improvement-theme/us/6)