### PR TITLE
Bugfix: path can no longer be empty string

### DIFF
--- a/app/models/support/requests/anonymous/anonymous_contact.rb
+++ b/app/models/support/requests/anonymous/anonymous_contact.rb
@@ -10,7 +10,7 @@ module Support
 
         validates :referrer, url: true, length: { maximum: 2048 }, allow_nil: true
         validates :url,      url: true, length: { maximum: 2048 }, allow_nil: true
-        validates :path,     url: true, length: { maximum: 2048 }, allow_nil: true
+        validates :path,     url: true, length: { maximum: 2048 }, presence: true
         validates :user_agent, length: { maximum: 2048 }
         validates :details, length: { maximum: 2 ** 16 }
         validates_inclusion_of :javascript_enabled, in: [ true, false ]

--- a/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
+++ b/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
@@ -63,8 +63,8 @@ module Support
 
         context "path" do
           it { should allow_value("/something").for(:path) }
-          it { should allow_value(nil).for(:path) }
           it { should allow_value("/" + ("a" * 2040)).for(:path) }
+          it { should_not allow_value("").for(:path) }
           it { should_not allow_value("/" + ("a" * 2050)).for(:path) }
           it { should_not allow_value("/méh/fào?bar").for(:path) }
         end

--- a/spec/models/support/requests/anonymous/problem_report_spec.rb
+++ b/spec/models/support/requests/anonymous/problem_report_spec.rb
@@ -27,13 +27,6 @@ module Support
               { path: "/vat-rates", total: 1 }
             ])
           end
-
-          it "ignores problem reports with null paths" do # there shouldn't really be any
-            create(:problem_report, path: "/vat-rates")
-            create(:problem_report, path: nil)
-
-            expect(result).to eq([ { path: "/vat-rates", total: 1 } ])
-          end
         end
       end
     end


### PR DESCRIPTION
Tightened path validation, as Errbit was throwing error
"No implicit conversion of nil into String" when path was "".

Path can no longer be nil

[Taiga story](https://tree.taiga.io/project/core-improvement-theme/us/14)

cc @benilovj 