### PR TITLE
Database migration to remove nil path entries

### DIFF
--- a/db/migrate/20150430133750_replace_empty_paths.rb
+++ b/db/migrate/20150430133750_replace_empty_paths.rb
@@ -1,0 +1,11 @@
+class ReplaceEmptyPaths < ActiveRecord::Migration
+  class ProblemReport < ActiveRecord::Base; end
+
+  def up
+    Support::Requests::Anonymous::ProblemReport.where(path: "").update_all(path: "/")
+  end
+
+  def down
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313183713) do
+ActiveRecord::Schema.define(version: 20150430133750) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255


### PR DESCRIPTION
Following a bug fix, entries with nil path will now be filtered by the validation
of the AnonymousContact class. Now replacing value of historic entries that
had a path set to nil, to a path of '/'.

cc @benilovj 

[Taiga](https://tree.taiga.io/project/core-improvement-theme/us/14)

Don't merge until #37 is deployed.