### PR TITLE
Migration to update empty paths to "/"

### DIFF
--- a/db/migrate/20150505100000_replace_empty_or_null_paths.rb
+++ b/db/migrate/20150505100000_replace_empty_or_null_paths.rb
@@ -1,0 +1,11 @@
+class ReplaceEmptyOrNullPaths < ActiveRecord::Migration
+  def up
+    Support::Requests::Anonymous::AnonymousContact.
+      unscoped.
+      where("path = '' or path is null").
+      update_all(path: "/")
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
This is necessary prior to adding a not-null constraint on the path
column.

Migration `20150430133750_replace_empty_paths.rb` didn't go quite far
enough to catch all of these records.

The timestamp on the new migration is before `20150505162618_path_not_null.rb`
so it runs before that one.

/cc @binaryberry 