### PR TITLE
Migrate the corporate content PP upload from Support app

### DIFF
--- a/app/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics.rb
+++ b/app/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics.rb
@@ -1,0 +1,118 @@
+require 'date'
+require_relative "problem_report"
+
+module Support
+  module Requests
+    module Anonymous
+      class FeedbackCounts
+        def initialize(first_day_of_period, period_in_question)
+          @first_day_of_period = first_day_of_period
+          @period_in_question = period_in_question
+        end
+
+        def to_a
+          counts = feedback_counts
+          absolute_count = feedback_counts.values.inject(:+)
+          feedback_counts.map do |page_owner, count|
+            {
+              "_id" => feedback_count_id_for(page_owner),
+              "_timestamp" => @first_day_of_period.to_time.iso8601,
+              "period" => "month",
+              "organisation_acronym" => page_owner,
+              "comment_count" => count,
+              "total_gov_uk_dept_and_policy_comment_count" => absolute_count
+            }
+          end
+        end
+
+        private
+        def feedback_counts
+          ProblemReport.
+            only_actionable.
+            with_known_page_owner.
+            where(created_at: @period_in_question).
+            order("page_owner asc").
+            group(:page_owner).
+            count
+        end
+
+        def feedback_count_id_for(page_owner)
+          "#{@first_day_of_period.strftime("%Y%m")}_#{page_owner}"
+        end
+      end
+
+      class TopUrls
+        NUMBER_OF_PATHS_PER_ORG = 5
+
+        def initialize(first_day_of_period, period_in_question)
+          @first_day_of_period = first_day_of_period
+          @period_in_question = period_in_question
+        end
+
+        def to_a
+          top_urls = distinct_org_acronyms.inject([]) do |list, org_acronym|
+            list + top_urls_for(org_acronym).zip(1..NUMBER_OF_PATHS_PER_ORG)
+          end
+          top_urls.map do |top_url, rank|
+            {
+              "_id" => top_url_id_for(top_url.page_owner, rank),
+              "_timestamp" => @first_day_of_period.to_time.iso8601,
+              "period" => "month",
+              "organisation_acronym" => top_url.page_owner,
+              "comment_count" => top_url.number_of_paths,
+              "url" => Plek.new.website_root + top_url.path
+            }
+          end
+        end
+
+        private
+        def top_urls_for(org_acronym)
+          ProblemReport.
+            only_actionable.
+            where(created_at: @period_in_question).
+            where(page_owner: org_acronym).
+            select("page_owner, path, count(*) as number_of_paths").
+            group(:path).
+            order("number_of_paths desc, path asc").
+            limit(NUMBER_OF_PATHS_PER_ORG)
+        end
+
+        def distinct_org_acronyms
+          ProblemReport.
+            only_actionable.
+            with_known_page_owner.
+            order("page_owner asc").
+            select(:page_owner).
+            uniq.
+            map(&:page_owner)
+        end
+
+        def top_url_id_for(page_owner, rank)
+          "#{@first_day_of_period.strftime("%Y%m")}_#{page_owner}_#{rank}"
+        end
+      end
+
+      class CorporateContentProblemReportAggregatedMetrics
+        def initialize(year, month)
+          @year = year
+          @month = month
+        end
+
+        def to_h
+          {
+            "feedback_counts" => FeedbackCounts.new(first_day_of_period, period_in_question).to_a,
+            "top_urls" => TopUrls.new(first_day_of_period, period_in_question).to_a
+          }
+        end
+
+        def period_in_question
+          first_day_of_period.beginning_of_day..first_day_of_period.end_of_month.end_of_day
+        end
+
+        def first_day_of_period
+          Date.new(@year, @month, 1)
+        end
+      end
+    end
+  end
+end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -18,6 +18,8 @@ module Support
             order("total desc")
         }
 
+        scope :with_known_page_owner, -> { where.not(page_owner: nil) }
+
         def content_item_path
           SupportApi::enhanced_content_api.content_item_path(path)
         end

--- a/app/workers/problem_report_stats_pp_uploader_worker.rb
+++ b/app/workers/problem_report_stats_pp_uploader_worker.rb
@@ -1,0 +1,26 @@
+require 'gds_api/performance_platform/data_in'
+require 'support/requests/anonymous/corporate_content_problem_report_aggregated_metrics'
+
+class ProblemReportStatsPPUploaderWorker
+  include Sidekiq::Worker
+  include Support::Requests::Anonymous
+
+  def perform(year, month)
+    logger.info("Uploading corporate content problem report statistics for #{year}-#{month}")
+    api = GdsApi::PerformancePlatform::DataIn.new(
+      PP_DATA_IN_API[:url],
+      bearer_token: PP_DATA_IN_API[:bearer_token]
+    )
+    stats = CorporateContentProblemReportAggregatedMetrics.new(year, month).to_h
+    response = api.corporate_content_problem_report_count(stats["feedback_counts"])
+    logger.info "Feedback counts push response: #{response.code}"
+    response = api.corporate_content_urls_with_the_most_problem_reports(stats["top_urls"])
+    logger.info "Top URLs counts push response: #{response.code}"
+  end
+
+  def self.run
+    first_day_of_last_month = Date.today.prev_month.at_beginning_of_month
+    perform_async(first_day_of_last_month.year, first_day_of_last_month.month)
+    Sidekiq::Logging.logger.info("Queued problem reports stats upload for month #{first_day_of_last_month.year}-#{first_day_of_last_month.month}")
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,6 +6,10 @@ set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
 # We need Rake to use our own environment
 job_type :rake, "cd :path && govuk_setenv support-api bundle exec rake :task :output"
 
+every 1.month, :at => '12:40 am' do
+  rake "performance_platform_uploads:push_problem_report_stats"
+end
+
 every 1.day, :at => '12:30 am' do
   rake "performance_platform_uploads:push_service_feedback"
 end

--- a/lib/tasks/performance_platform_uploads.rake
+++ b/lib/tasks/performance_platform_uploads.rake
@@ -19,4 +19,14 @@ namespace :performance_platform_uploads do
       puts "ProblemReportDailyTotalsPPUploaderWorker invoked"
     end
   end
+
+  desc "Trigger an upload of problem report stats (grouped by dept) to the performance platform"
+  task :push_problem_report_stats => :environment do
+    require 'distributed_lock'
+
+    DistributedLock.new('support:problem_report_stats_to_pp').lock do
+      ProblemReportStatsPPUploaderWorker.run
+      puts "ProblemReportStatsPPUploaderWorker invoked"
+    end
+  end
 end

--- a/spec/integration/corporate_content_problem_report_stats_spec.rb
+++ b/spec/integration/corporate_content_problem_report_stats_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'time'
+require 'json'
+require 'gds_api/test_helpers/performance_platform/data_in'
+
+describe "corporate content problem report stats" do
+  include GdsApi::TestHelpers::PerformancePlatform::DataIn
+
+  it "is pushed to the performance platform for the previous month" do
+    stub_post1 = stub_corporate_content_problem_report_count_submission([
+      {
+        "_id" => "201301_dft",
+        "_timestamp" => "2013-01-01T00:00:00+00:00",
+        "period" => "month",
+        "organisation_acronym" => "dft",
+        "comment_count" => 1,
+        "total_gov_uk_dept_and_policy_comment_count" => 1
+      }
+    ])
+    stub_post2 = stub_corporate_content_urls_with_the_most_problem_reports_submission([
+      {
+        "_id" => "201301_dft_1",
+        "_timestamp" => "2013-01-01T00:00:00+00:00",
+        "period" => "month",
+        "organisation_acronym" => "dft",
+        "comment_count" => 1,
+        "url" => "http://www.dev.gov.uk/abc"
+      }
+    ])
+
+    Timecop.travel Time.parse("2013-01-15 12:00:00")
+
+    create(:problem_report,
+      what_wrong: "this service is great",
+      path: "/abc",
+      page_owner: "dft"
+    )
+
+    Timecop.travel Time.parse("2013-02-01 12:00:00")
+
+    ProblemReportStatsPPUploaderWorker.run
+
+    expect(stub_post1).to have_been_made
+    expect(stub_post2).to have_been_made
+  end
+
+  after do
+    Timecop.return
+  end
+end

--- a/spec/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics_spec.rb
+++ b/spec/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+require 'support/requests/anonymous/corporate_content_problem_report_aggregated_metrics'
+
+module Support
+  module Requests
+    module Anonymous
+      describe CorporateContentProblemReportAggregatedMetrics do
+        def create_report(options)
+          defaults = {
+            javascript_enabled: true,
+            is_actionable: true,
+          }
+          f = ProblemReport.create!(defaults.merge(options))
+          f.update_attribute(:created_at, options[:created_at])
+        end
+
+        before do
+          { 7 => ["a"], 5 => ["b", "c", "d"], 3 => ["e", "f"], 1 => ["g"] }.each do |count, slugs|
+            slugs.each do |slug|
+              count.times { create_report(page_owner: "co", created_at: Date.new(2013,2,10), path: "/#{slug}") }
+            end
+          end
+
+          create_report(page_owner: "dft", created_at: Date.new(2013,2,10), path: "/h")
+          create_report(page_owner: "hmrc", created_at: Date.new(2013,2,10), path: "/i")
+          create_report(page_owner: "co", created_at: Date.new(2013,1,1), path: "/a")
+        end
+
+        after do
+          ProblemReport.delete_all
+        end
+
+        let(:metrics) { CorporateContentProblemReportAggregatedMetrics.new(2013, 2).to_h }
+
+        context "counts" do
+          let(:feedback_counts) { metrics["feedback_counts"] }
+
+          context "metadata" do
+            it "generates ids based on the slug and date" do
+              ids = feedback_counts.map {|entry| entry["_id"] }
+              expect(ids).to eq([ "201302_co", "201302_dft", "201302_hmrc" ])
+            end
+
+            it "sets the period to a day" do
+              periods = feedback_counts.map {|entry| entry["period"] }
+              expect(periods.uniq).to eq([ "month" ])
+            end
+
+            it "sets the start time correctly" do
+              timestamps = feedback_counts.map {|entry| entry["_timestamp"] }
+              expect(timestamps.uniq).to eq([ "2013-02-01T00:00:00+00:00" ])
+            end
+          end
+
+          context "aggregated metrics" do
+            it "includes comment counts, grouped by page owner" do
+              counts = feedback_counts.map {|entry| [ entry["organisation_acronym"], entry["comment_count"] ] }
+              expect(counts).to eq([ ["co", 29], ["dft", 1], ["hmrc", 1] ])
+            end
+
+            it "includes the absolute count" do
+              absolute_counts = feedback_counts.map {|entry| entry["total_gov_uk_dept_and_policy_comment_count"] }
+              expect(absolute_counts.uniq).to eq([ 31 ])
+            end
+          end
+        end
+
+        context "top urls" do
+          let(:top_urls) { metrics["top_urls"] }
+
+          context "metadata" do
+            it "generates ids based on the slug and date" do
+              ids = top_urls.map {|entry| entry["_id"] }
+              expected_ids = (1..5).map {|n| "201302_co_#{n}" } + ["201302_dft_1", "201302_hmrc_1"]
+              expect(ids).to eq(expected_ids)
+            end
+
+            it "sets the period to a day" do
+              periods = top_urls.map {|entry| entry["period"] }
+              expect(periods.uniq).to eq([ "month" ])
+            end
+
+            it "sets the start time correctly" do
+              timestamps = top_urls.map {|entry| entry["_timestamp"] }
+              expect(timestamps.uniq).to eq([ "2013-02-01T00:00:00+00:00" ])
+            end
+          end
+
+          context "aggregated metrics" do
+            it "includes urls, comment counts, grouped by page owner" do
+              aggregates = top_urls.map {|entry| [ entry["organisation_acronym"], entry["url"], entry["comment_count"] ] }
+              expect(aggregates).to eq([
+                ["co", "http://www.dev.gov.uk/a", 7],
+                ["co", "http://www.dev.gov.uk/b", 5],
+                ["co", "http://www.dev.gov.uk/c", 5],
+                ["co", "http://www.dev.gov.uk/d", 5],
+                ["co", "http://www.dev.gov.uk/e", 3],
+                ["dft", "http://www.dev.gov.uk/h", 1],
+                ["hmrc", "http://www.dev.gov.uk/i", 1],
+              ])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/workers/problem_report_stats_pp_uploader_worker_spec.rb
+++ b/spec/models/workers/problem_report_stats_pp_uploader_worker_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'date'
+require 'gds_api/test_helpers/performance_platform/data_in'
+
+describe ProblemReportStatsPPUploaderWorker do
+  include GdsApi::TestHelpers::PerformancePlatform::DataIn
+
+  it "pushes last month's problem report stats for Whitehall content (aggregated by org) to the performance platform" do
+    Timecop.travel Date.new(2013,2,1)
+
+    allow(Support::Requests::Anonymous::CorporateContentProblemReportAggregatedMetrics).to receive(:new).with(2013,1).and_return(
+      double(to_h: { "feedback_counts" => [ :some, :counts ], "top_urls" => [ :some, :top, :urls ] })
+    )
+
+    stub_post1 = stub_corporate_content_problem_report_count_submission([ :some, :counts ])
+    stub_post2 = stub_corporate_content_urls_with_the_most_problem_reports_submission([ :some, :top, :urls ])
+
+    ProblemReportStatsPPUploaderWorker.run
+
+    expect(stub_post1).to have_been_made
+    expect(stub_post2).to have_been_made
+  end
+end


### PR DESCRIPTION
The monthly upload of corporate content stats to the PP used to live
and run within the Support app, but belongs within the Support API,
closer to the data.

This upload was originally added to the Support app in https://github.com/alphagov/support/pull/156.

This data supports provides data to the feedback modules of the
performance platform GOV.UK web traffic dashboards
(https://www.gov.uk/performance/web-traffic).