### PR TITLE
Derive the AnonymousContact url from path

### DIFF
--- a/app/models/support/requests/anonymous/anonymous_contact.rb
+++ b/app/models/support/requests/anonymous/anonymous_contact.rb
@@ -6,10 +6,8 @@ module Support
     module Anonymous
       class AnonymousContact < ActiveRecord::Base
         before_save :detect_personal_information
-        before_save :set_path_from_url
 
         validates :referrer, url: true, length: { maximum: 2048 }, allow_nil: true
-        validates :url,      url: true, length: { maximum: 2048 }, allow_nil: true
         validates :path,     url: true, length: { maximum: 2048 }, presence: true
         validates :user_agent, length: { maximum: 2048 }
         validates :details, length: { maximum: 2 ** 16 }
@@ -36,6 +34,10 @@ module Support
           end
         end
 
+        def url
+          Plek.new.website_root + (path || "")
+        end
+
         def mark_as_duplicate
           self.is_actionable = false
           self.reason_why_not_actionable = "duplicate"
@@ -50,10 +52,6 @@ module Support
         def personal_info_present?
           free_text_fields = [ self.details, self.what_wrong, self.what_doing ]
           free_text_fields.any? { |text| FieldWhichMayContainPersonalInformation.new(text).include_personal_info? }
-        end
-
-        def set_path_from_url
-          self.path = URI.parse(url).path unless url.blank?
         end
       end
     end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -28,10 +28,6 @@ module Support
           "problem-report"
         end
 
-        def url
-          path ? Plek.new.website_root + path : nil
-        end
-
         def as_json(options)
           super(only: [ :type, :url, :id, :created_at, :what_wrong, :what_doing, :referrer, :user_agent ])
         end

--- a/app/models/support/requests/anonymous/problem_report.rb
+++ b/app/models/support/requests/anonymous/problem_report.rb
@@ -29,7 +29,8 @@ module Support
         end
 
         def as_json(options)
-          super(only: [ :type, :url, :id, :created_at, :what_wrong, :what_doing, :referrer, :user_agent ])
+          super(only: [ :type, :id, :created_at, :what_wrong, :what_doing, :referrer, :user_agent ]).
+            merge(url: url)
         end
 
         def self.to_csv(reports)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505162618) do
+ActiveRecord::Schema.define(version: 20150513094727) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20150505162618) do
     t.text     "details",                     limit: 65535
     t.string   "source",                      limit: 255
     t.string   "page_owner",                  limit: 255
-    t.text     "url",                         limit: 65535
     t.text     "user_agent",                  limit: 65535
     t.string   "referrer",                    limit: 2048
     t.boolean  "javascript_enabled",          limit: 1

--- a/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
+++ b/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
@@ -7,7 +7,7 @@ module Support
   module Requests
     module Anonymous
       describe AnonymousContact, :type => :model do
-        DEFAULTS = { javascript_enabled: true, url: "https://www.gov.uk/tax-disc", path: "/tax-disc" }
+        DEFAULTS = { javascript_enabled: true, path: "/tax-disc" }
 
         def new_contact(options = {})
           TestContact.new(DEFAULTS.merge(options))
@@ -47,18 +47,10 @@ module Support
           expect(new_contact(personal_information_status: "abcde")).to_not be_valid
         end
 
-        it "stores the relative path of the page from which the feedback was lodged" do
-          contact = new_contact(url: "https://www.gov.uk/vat-rates")
-          contact.save!
-          expect(contact.path).to eq("/vat-rates")
-        end
-
         context "URLs" do
-          it { should allow_value("https://www.gov.uk/something").for(:url) }
-          it { should allow_value(nil).for(:url) }
-          it { should allow_value("http://" + ("a" * 2040)).for(:url) }
-          it { should_not allow_value("http://" + ("a" * 2050)).for(:url) }
-          it { should_not allow_value("http://bla.example.org:9292/méh/fào?bar").for(:url) }
+          it "should be derived from the path" do
+            expect(new_contact(path: "/vat-rates").url).to eq("http://www.dev.gov.uk/vat-rates")
+          end
         end
 
         context "path" do


### PR DESCRIPTION
Some time ago, the `AnonymousContact#path` started being used instead
of `AnonymousContact#url`.

Currently:

- no endpoints accept the `url` as an attribute
- `path` has a not-null constraint 
- all the non-null paths in the database have been cleaned up

This means that we can drop all remaining uses of the `url` field and derive it from `path` completely. The next step would be dropping the column from the database, once the Support app no longer relies on
the database.