### PR TITLE
Add support for date ranges

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -8,11 +8,13 @@ class AnonymousFeedbackController < ApplicationController
     from_date = parse_date(params[:from])
     to_date = parse_date(params[:to])
 
+    from_date, to_date = [from_date, to_date].sort if from_date && to_date
+
     results = AnonymousContact.
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
-      created_between_days(from_date, to_date).
+      created_between_days(from_date || Time.at(0), to_date || Time.now).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -9,6 +9,7 @@ class AnonymousFeedbackController < ApplicationController
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
+      created_between(parse_date(params[:from]), parse_date(params[:to])).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)
@@ -21,4 +22,12 @@ class AnonymousFeedbackController < ApplicationController
       page_size: AnonymousContact::PAGE_SIZE,
     }
   end
+
+  def parse_date(date)
+    return nil if date.nil?
+    parsed_date = Date.parse(date)
+  rescue ArgumentError
+    return nil
+  end
+
 end

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -14,7 +14,7 @@ class AnonymousFeedbackController < ApplicationController
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
-      created_between_days(from_date || Time.at(0), to_date || Time.now).
+      created_between_days(from_date || Date.new(1970), to_date || Date.today).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -5,22 +5,30 @@ class AnonymousFeedbackController < ApplicationController
       return
     end
 
+    from_date = parse_date(params[:from])
+    to_date = parse_date(params[:to])
+
     results = AnonymousContact.
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
-      created_between_days(parse_date(params[:from]), parse_date(params[:to])).
+      created_between_days(from_date, to_date).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)
 
-    render json: {
+    json = {
       results: results,
       total_count: results.total_count,
       current_page: results.current_page,
       pages: results.total_pages,
       page_size: AnonymousContact::PAGE_SIZE,
     }
+
+    json[:from_date] = from_date if from_date
+    json[:to_date] = to_date if to_date
+
+    render json: json
   end
 
   def parse_date(date)

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -9,7 +9,7 @@ class AnonymousFeedbackController < ApplicationController
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
-      created_between(parse_date(params[:from]), parse_date(params[:to])).
+      created_between_days(parse_date(params[:from]), parse_date(params[:to])).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -19,10 +19,10 @@ class AnonymousContact < ActiveRecord::Base
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
-  scope :created_between, -> (first_date, last_date) do
+  scope :created_between_days, -> (first_date, last_date) do
     first_date ||= Time.at(0)
     last_date ||= Time.now
-    where(created_at: first_date..last_date)
+    where(created_at: first_date.at_beginning_of_day..last_date.at_end_of_day)
   end
 
   PAGE_SIZE = 50

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -20,9 +20,6 @@ class AnonymousContact < ActiveRecord::Base
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
   scope :created_between_days, -> (first_date, last_date) do
-    first_date ||= Time.at(0)
-    last_date ||= Time.now
-    first_date, last_date = [first_date, last_date].sort
     where(created_at: first_date.at_beginning_of_day..last_date.at_end_of_day)
   end
 

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -19,6 +19,11 @@ class AnonymousContact < ActiveRecord::Base
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
+  scope :created_between, -> (first_date, last_date) do
+    first_date ||= Time.at(0)
+    last_date ||= Time.now
+    where(created_at: first_date..last_date)
+  end
 
   PAGE_SIZE = 50
   paginates_per PAGE_SIZE

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -19,9 +19,7 @@ class AnonymousContact < ActiveRecord::Base
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
-  scope :created_between_days, -> (first_date, last_date) do
-    where(created_at: first_date.at_beginning_of_day..last_date.at_end_of_day)
-  end
+  scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
 
   PAGE_SIZE = 50
   paginates_per PAGE_SIZE

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -22,6 +22,7 @@ class AnonymousContact < ActiveRecord::Base
   scope :created_between_days, -> (first_date, last_date) do
     first_date ||= Time.at(0)
     last_date ||= Time.now
+    first_date, last_date = [first_date, last_date].sort
     where(created_at: first_date.at_beginning_of_day..last_date.at_end_of_day)
   end
 

--- a/db/migrate/20150518151221_add_index_to_anonymous_contacts_on_created_at.rb
+++ b/db/migrate/20150518151221_add_index_to_anonymous_contacts_on_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToAnonymousContactsOnCreatedAt < ActiveRecord::Migration
+  def change
+  	add_index "anonymous_contacts", ["created_at"], name: "index_anonymous_contacts_on_created_at", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150515222831) do
+ActiveRecord::Schema.define(version: 20150518151221) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20150515222831) do
     t.integer  "content_item_id",             limit: 4
   end
 
+  add_index "anonymous_contacts", ["created_at"], name: "index_anonymous_contacts_on_created_at", using: :btree
   add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>255}, using: :btree
 
   create_table "content_items", force: :cascade do |t|

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -121,6 +121,25 @@ describe AnonymousFeedbackController do
           )
         end
       end
+
+      context "dates entered in non-chronological order" do
+        let(:to)  {"13th December 2014"}
+        let(:from) {"24/11/2014"}
+
+        it "returns relevant contacts" do
+          request
+
+          expect(json_response).to eq(
+            "results" =>JSON.parse([@newest_contact, @third_contact].to_json),
+            "page_size" => 50,
+            "total_count" => 2,
+            "current_page" => 1,
+            "pages" => 1,
+            "to_date" => "2014-12-13",
+            "from_date" => "2014-11-24",
+          )
+        end
+      end
     end
   end
 

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -78,6 +78,8 @@ describe AnonymousFeedbackController do
 
           expect(json_response).to eq(
             "results" =>JSON.parse([@third_contact, @second_contact].to_json),
+            "from_date" => "2014-10-13",
+            "to_date" => "2014-12-01",
             "page_size" => 50,
             "total_count" => 2,
             "current_page" => 1,
@@ -98,6 +100,7 @@ describe AnonymousFeedbackController do
             "total_count" => 3,
             "current_page" => 1,
             "pages" => 1,
+            "from_date" => "2014-10-13",
           )
         end
       end
@@ -114,6 +117,7 @@ describe AnonymousFeedbackController do
             "total_count" => 3,
             "current_page" => 1,
             "pages" => 1,
+            "to_date" => "2014-12-01",
           )
         end
       end

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -38,5 +38,109 @@ describe AnonymousFeedbackController do
         "pages" => 1,
       )
     end
+
+    describe "from and to parameters" do
+      let(:first_date)  { Time.new(2014, 01, 01) }
+      let(:second_date) { Time.new(2014, 10, 31) }
+      let(:third_date)  { Time.new(2014, 11, 25) }
+      let(:last_date)   { Time.new(2014, 12, 12) }
+      let(:request)     { get :index, path_prefix: "/", from: from, to: to }
+      let(:from)        { nil }
+      let(:to)          { nil }
+
+      before do
+        @first_contact = create(:anonymous_contact, created_at: first_date).reload
+        @second_contact = create(:anonymous_contact, created_at: second_date).reload
+        @third_contact = create(:anonymous_contact, created_at: third_date).reload
+        @newest_contact = create(:anonymous_contact, created_at: last_date).reload
+      end
+
+      context "when no to and from dates specified" do
+        it "should return all the contacts" do
+          request
+
+          expect(json_response).to eq(
+            "results" =>JSON.parse([@newest_contact, @third_contact, @second_contact, @first_contact].to_json),
+            "page_size" => 50,
+            "total_count" => 4,
+            "current_page" => 1,
+            "pages" => 1,
+          )
+        end
+      end
+
+      context "human readable dates for 'from' and 'to'" do
+        let(:from)  {"13/10/2014"}
+        let(:to)    {"1st December 2014"}
+
+        it "returns relevant contacts" do
+          request
+
+          expect(json_response).to eq(
+            "results" =>JSON.parse([@third_contact, @second_contact].to_json),
+            "page_size" => 50,
+            "total_count" => 2,
+            "current_page" => 1,
+            "pages" => 1,
+          )
+        end
+      end
+
+      context "only 'from' date specified" do
+        let(:from)  {"13/10/2014"}
+
+        it "returns relevant contacts" do
+          request
+
+          expect(json_response).to eq(
+            "results" =>JSON.parse([@newest_contact, @third_contact, @second_contact].to_json),
+            "page_size" => 50,
+            "total_count" => 3,
+            "current_page" => 1,
+            "pages" => 1,
+          )
+        end
+      end
+
+      context "only 'to' date specified" do
+        let(:to)  {"1st December 2014"}
+
+        it "returns relevant contacts" do
+          request
+
+          expect(json_response).to eq(
+            "results" =>JSON.parse([@third_contact, @second_contact, @first_contact].to_json),
+            "page_size" => 50,
+            "total_count" => 3,
+            "current_page" => 1,
+            "pages" => 1,
+          )
+        end
+      end
+    end
+  end
+
+  describe "parse_date" do
+    subject() { described_class.new.parse_date(input) }
+
+    context "with a valid short form date" do
+      let(:input) {"13/10/2014"}
+      it {is_expected.to eq(Time.new(2014, 10, 13))}
+    end
+
+    context "with a valid long form date" do
+      let(:input) {"1st December 2014"}
+      it {is_expected.to eq(Time.new(2014, 12, 1))}
+    end
+    context "with a nil date" do
+      let(:input) { nil }
+      it {is_expected.to be_nil}
+    end
+
+    context "with an invalid date" do
+      let(:input) {"foo"}
+      it {is_expected.to be_nil}
+    end
+
   end
 end

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -40,10 +40,10 @@ describe AnonymousFeedbackController do
     end
 
     describe "from and to parameters" do
-      let(:first_date)  { Time.new(2014, 01, 01) }
-      let(:second_date) { Time.new(2014, 10, 31) }
-      let(:third_date)  { Time.new(2014, 11, 25) }
-      let(:last_date)   { Time.new(2014, 12, 12) }
+      let(:first_date)  { Time.new(2014, 01, 01).utc }
+      let(:second_date) { Time.new(2014, 10, 31).utc }
+      let(:third_date)  { Time.new(2014, 11, 25).utc }
+      let(:last_date)   { Time.new(2014, 12, 12).utc }
       let(:request)     { get :index, path_prefix: "/", from: from, to: to }
       let(:from)        { nil }
       let(:to)          { nil }
@@ -148,12 +148,12 @@ describe AnonymousFeedbackController do
 
     context "with a valid short form date" do
       let(:input) {"13/10/2014"}
-      it {is_expected.to eq(Time.new(2014, 10, 13))}
+      it {is_expected.to eq(Date.new(2014, 10, 13))}
     end
 
     context "with a valid long form date" do
       let(:input) {"1st December 2014"}
-      it {is_expected.to eq(Time.new(2014, 12, 1))}
+      it {is_expected.to eq(Date.new(2014, 12, 1))}
     end
     context "with a nil date" do
       let(:input) { nil }

--- a/spec/integration/corporate_content_problem_report_stats_spec.rb
+++ b/spec/integration/corporate_content_problem_report_stats_spec.rb
@@ -44,7 +44,4 @@ describe "corporate content problem report stats" do
     expect(stub_post2).to have_been_made
   end
 
-  after do
-    Timecop.return
-  end
 end

--- a/spec/integration/deduplication_spec.rb
+++ b/spec/integration/deduplication_spec.rb
@@ -62,8 +62,4 @@ describe "de-duplication" do
         only_actionable.order(:created_at).to_a).to eq([record1, record2])
     end
   end
-
-  after do
-    Timecop.return
-  end
 end

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -127,7 +127,7 @@ describe AnonymousContact, :type => :model do
       end
 
       it "returns the items that are included in the date interval" do
-        expect(AnonymousContact.created_between_days(second_date + 12.hours, last_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
+        expect(AnonymousContact.created_between_days(second_date.to_date, last_date.to_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
       end
 
     end

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -112,6 +112,41 @@ describe AnonymousContact, :type => :model do
 
       expect(AnonymousContact.only_actionable).to eq([a])
     end
+
+    describe "created_between" do
+      let(:first_date) { Time.new(2014, 01, 01) }
+      let(:second_date) { Time.new(2014, 10, 31) }
+      let(:third_date){ Time.new(2014, 11, 25) }
+      let(:last_date) { Time.new(2014, 12, 12) }
+
+      before do
+        @first_contact = new_contact(created_at: first_date)
+        @second_contact = new_contact(created_at: second_date)
+        @third_contact = new_contact(created_at: third_date)
+        @newest_contact = new_contact(created_at: last_date)
+        @first_contact.save!
+        @second_contact.save!
+        @third_contact.save!
+        @newest_contact.save!
+      end
+
+      it "returns the items that are included in the date interval" do
+        expect(AnonymousContact.created_between(second_date, last_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
+      end
+
+      it "accepts an open date range for the first date" do
+        expect(AnonymousContact.created_between(nil, second_date).sort).to eq([@first_contact, @second_contact])
+      end
+
+      it "accepts an open date range for the last date" do
+        expect(AnonymousContact.created_between(second_date, nil).sort).to eq([@second_contact, @third_contact, @newest_contact])
+      end
+
+      it "returns all the items when no date range has been selected" do
+        expect(AnonymousContact.created_between(nil, nil).sort).to eq([@first_contact, @second_contact, @third_contact, @newest_contact])
+      end
+
+    end
   end
 
   describe "pagination" do

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -145,6 +145,11 @@ describe AnonymousContact, :type => :model do
       it "returns all the items when no date range has been selected" do
         expect(AnonymousContact.created_between_days(nil, nil).sort).to eq([@first_contact, @second_contact, @third_contact, @newest_contact])
       end
+
+      it "returns the relevant items when the dates are given in the wrong order" do
+        expect(AnonymousContact.created_between_days(last_date, second_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
+      end
+
     end
   end
 

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -113,7 +113,7 @@ describe AnonymousContact, :type => :model do
       expect(AnonymousContact.only_actionable).to eq([a])
     end
 
-    describe "created_between" do
+    describe "created_between_days" do
       let(:first_date) { Time.new(2014, 01, 01) }
       let(:second_date) { Time.new(2014, 10, 31) }
       let(:third_date){ Time.new(2014, 11, 25) }
@@ -123,7 +123,7 @@ describe AnonymousContact, :type => :model do
         @first_contact = new_contact(created_at: first_date)
         @second_contact = new_contact(created_at: second_date)
         @third_contact = new_contact(created_at: third_date)
-        @newest_contact = new_contact(created_at: last_date)
+        @newest_contact = new_contact(created_at: last_date + 12.hours)
         @first_contact.save!
         @second_contact.save!
         @third_contact.save!
@@ -131,21 +131,20 @@ describe AnonymousContact, :type => :model do
       end
 
       it "returns the items that are included in the date interval" do
-        expect(AnonymousContact.created_between(second_date, last_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
+        expect(AnonymousContact.created_between_days(second_date + 12.hours, last_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
       end
 
       it "accepts an open date range for the first date" do
-        expect(AnonymousContact.created_between(nil, second_date).sort).to eq([@first_contact, @second_contact])
+        expect(AnonymousContact.created_between_days(nil, second_date).sort).to eq([@first_contact, @second_contact])
       end
 
       it "accepts an open date range for the last date" do
-        expect(AnonymousContact.created_between(second_date, nil).sort).to eq([@second_contact, @third_contact, @newest_contact])
+        expect(AnonymousContact.created_between_days(second_date, nil).sort).to eq([@second_contact, @third_contact, @newest_contact])
       end
 
       it "returns all the items when no date range has been selected" do
-        expect(AnonymousContact.created_between(nil, nil).sort).to eq([@first_contact, @second_contact, @third_contact, @newest_contact])
+        expect(AnonymousContact.created_between_days(nil, nil).sort).to eq([@first_contact, @second_contact, @third_contact, @newest_contact])
       end
-
     end
   end
 

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -120,34 +120,14 @@ describe AnonymousContact, :type => :model do
       let(:last_date) { Time.new(2014, 12, 12) }
 
       before do
-        @first_contact = new_contact(created_at: first_date)
-        @second_contact = new_contact(created_at: second_date)
-        @third_contact = new_contact(created_at: third_date)
-        @newest_contact = new_contact(created_at: last_date + 12.hours)
-        @first_contact.save!
-        @second_contact.save!
-        @third_contact.save!
-        @newest_contact.save!
+        @first_contact = contact(created_at: first_date)
+        @second_contact = contact(created_at: second_date)
+        @third_contact = contact(created_at: third_date)
+        @newest_contact = contact(created_at: last_date + 12.hours)
       end
 
       it "returns the items that are included in the date interval" do
         expect(AnonymousContact.created_between_days(second_date + 12.hours, last_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
-      end
-
-      it "accepts an open date range for the first date" do
-        expect(AnonymousContact.created_between_days(nil, second_date).sort).to eq([@first_contact, @second_contact])
-      end
-
-      it "accepts an open date range for the last date" do
-        expect(AnonymousContact.created_between_days(second_date, nil).sort).to eq([@second_contact, @third_contact, @newest_contact])
-      end
-
-      it "returns all the items when no date range has been selected" do
-        expect(AnonymousContact.created_between_days(nil, nil).sort).to eq([@first_contact, @second_contact, @third_contact, @newest_contact])
-      end
-
-      it "returns the relevant items when the dates are given in the wrong order" do
-        expect(AnonymousContact.created_between_days(last_date, second_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ SimpleCov.start 'rails'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+
+  config.after(:each) do
+    Timecop.return
+  end
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Support-api can now return anonymous contacts for selected date ranges. 
The date ranges are inclusive, can be given in non-chronological order, and the app can handle none, 1 or 2 dates being defined. 
Anonymous contacts also indexed by creation date.
Also moved Timecop.return to spec_helper to ensure it was run after each test.