### PR TITLE
Reinstate necessary require statement

### DIFF
--- a/app/workers/service_feedback_pp_uploader_worker.rb
+++ b/app/workers/service_feedback_pp_uploader_worker.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'gds_api/performance_platform/data_in'
+require 'service_feedback_aggregated_metrics'
 
 class ServiceFeedbackPPUploaderWorker
   include Sidekiq::Worker


### PR DESCRIPTION
It seems that I was too overzealous in https://github.com/alphagov/support-api/pull/49
and removed a require that's necessary for the worker to run.

This fixes an [errbit issue](https://errbit.preview.alphagov.co.uk/apps/53be40ba0da1154d55001fcb/problems/555a840d65786342cf270000).