### PR TITLE
Query the database more efficiently in AnonymousFeedbackController

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -5,12 +5,11 @@ class AnonymousFeedbackController < ApplicationController
       return
     end
 
-    query = AnonymousContact.
+    results = AnonymousContact.
       only_actionable.
       free_of_personal_info.
       matching_path_prefix(params[:path_prefix]).
-      most_recent_first
-    results = Kaminari.paginate_array(query).
+      most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)
 


### PR DESCRIPTION
Before this fix, the page limits weren't being applied to the ActiveRecord
queries because of inappropriate use of Kaminari. This meant that
for paths with lots of feedback, everything was being loaded into
memory before being limited to just one page.

The fix means that the limits are applied directly in the DB query.