### PR TITLE
Endpoint for each organisation with recent feedback counts

### DIFF
--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -9,8 +9,7 @@ module AnonymousFeedback
       organisation = Organisation.find_by(slug: params[:slug])
       anonymous_feedback_counts = ContentItem.
         for_organisation(organisation).
-        summary.
-        sort_by { |r| -1 * r[:last_7_days] }
+        summary("last_7_days")
 
       render json: {
         slug: organisation.slug,

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -4,5 +4,19 @@ module AnonymousFeedback
       organisations = Organisation.order(:slug)
       render json: organisations
     end
+
+    def show
+      organisation = Organisation.find_by(slug: params[:slug])
+      anonymous_feedback_counts = ContentItem.
+        for_organisation(organisation).
+        summary.
+        sort_by { |r| -1 * r[:last_7_days] }
+
+      render json: {
+        slug: organisation.slug,
+        title: organisation.title,
+        anonymous_feedback_counts: anonymous_feedback_counts,
+      }
+    end
   end
 end

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -6,10 +6,15 @@ module AnonymousFeedback
     end
 
     def show
+      if %w(path last_7_days last_30_days last_90_days).include? params[:ordering]
+        ordering = params[:ordering]
+      else
+        ordering = "last_7_days"
+      end
       organisation = Organisation.find_by(slug: params[:slug])
       anonymous_feedback_counts = ContentItem.
         for_organisation(organisation).
-        summary("last_7_days")
+        summary(ordering)
 
       render json: {
         slug: organisation.slug,

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -11,24 +11,19 @@ class ContentItem < ActiveRecord::Base
     where("organisations.id = ?", organisation.id)
   }
 
-  def self.summary
+  def self.summary(ordering="last_7_days")
     midnight_last_night = Date.today.to_time(:utc)
 
-    joins(:anonymous_contacts).
-    select("content_items.path as path").
-    select(sum_column(from: midnight_last_night - 7.days, to: midnight_last_night, column_name: "last_7_days")).
-    select(sum_column(from: midnight_last_night - 30.days, to: midnight_last_night, column_name: "last_30_days")).
-    select(sum_column(from: midnight_last_night - 90.days, to: midnight_last_night, column_name: "last_90_days")).
-    group("content_items.id").
-    reject {|r| [ r.last_7_days, r.last_30_days, r.last_90_days ].sum == 0 }.
-    map { |r|
-      {
-        path: r.path,
-        last_7_days: r.last_7_days,
-        last_30_days: r.last_30_days,
-        last_90_days: r.last_90_days
-      }
-    }
+    query = joins(:anonymous_contacts).
+      select("content_items.path as path").
+      select(sum_column(from: midnight_last_night - 7.days, to: midnight_last_night, column_name: "last_7_days")).
+      select(sum_column(from: midnight_last_night - 30.days, to: midnight_last_night, column_name: "last_30_days")).
+      select(sum_column(from: midnight_last_night - 90.days, to: midnight_last_night, column_name: "last_90_days")).
+      group("content_items.id").
+      having("last_7_days + last_30_days + last_90_days > 0").
+      order("#{ordering} DESC")
+
+    connection.select_all(query).map(&:symbolize_keys)
   end
 
 private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,11 +1,45 @@
 class ContentItem < ActiveRecord::Base
   has_and_belongs_to_many :organisations
   has_many :problem_reports, class_name: "ProblemReport"
+  has_many :anonymous_contacts
   validates :path, presence: true
 
   before_create :fetch_organisations, unless: ->(content_item) { content_item.organisations.present? }
 
-  private
+  scope :for_organisation, ->(organisation) {
+    joins(:organisations).
+    where("organisations.id = ?", organisation.id)
+  }
+
+  def self.summary
+    midnight_last_night = Date.today.to_time(:utc)
+
+    joins(:anonymous_contacts).
+    select("content_items.path as path").
+    select(sum_column(from: midnight_last_night - 7.days, to: midnight_last_night, column_name: "last_7_days")).
+    select(sum_column(from: midnight_last_night - 30.days, to: midnight_last_night, column_name: "last_30_days")).
+    select(sum_column(from: midnight_last_night - 90.days, to: midnight_last_night, column_name: "last_90_days")).
+    group("content_items.id").
+    reject {|r| [ r.last_7_days, r.last_30_days, r.last_90_days ].sum == 0 }.
+    map { |r|
+      {
+        path: r.path,
+        last_7_days: r.last_7_days,
+        last_30_days: r.last_30_days,
+        last_90_days: r.last_90_days
+      }
+    }
+  end
+
+private
+  def self.sum_column(options)
+    "SUM(
+       CASE WHEN anonymous_contacts.created_at BETWEEN '#{options[:from].to_s(:db)}' AND '#{options[:to].to_s(:db)}' THEN 1
+            ELSE 0
+            END
+        ) AS #{options[:column_name]}"
+  end
+
   def fetch_organisations
     self.organisations = Organisation.for_path(path)
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -3,7 +3,7 @@ class ContentItem < ActiveRecord::Base
   has_many :problem_reports, class_name: "ProblemReport"
   validates :path, presence: true
 
-  before_create :fetch_organisations
+  before_create :fetch_organisations, unless: ->(content_item) { content_item.organisations.present? }
 
   private
   def fetch_organisations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,10 +32,9 @@ Rails.application.routes.draw do
         constraints: { period: /\d{4}-\d{2}(-\d{2})?/ },
         to: 'problem_reports#index'
 
-    get 'organisations',
+    resources 'organisations',
         only: :index,
-        format: false,
-        to: "organisations#index"
+        format: false
   end
 
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,8 +33,9 @@ Rails.application.routes.draw do
         to: 'problem_reports#index'
 
     resources 'organisations',
-        only: :index,
-        format: false
+        only: [:index, :show],
+        format: false,
+        param: :slug
   end
 
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }

--- a/import.rb
+++ b/import.rb
@@ -1,0 +1,20 @@
+require 'csv'
+
+csvs = Dir.glob('tmp/data/*.csv')
+csvs.each do |file_path|
+  table = CSV.table(file_path)
+  table.each do |row|
+    path = row[:where_feedback_was_left].gsub("https://www.gov.uk", "")
+    what_doing, what_wrong = row[:feedback].scan(/action: (.*?)\nproblem: (.*)/m)[0]
+    referrer = row[:user_came_from]
+
+    ProblemReport.create!(
+      path: path,
+      what_doing: what_doing,
+      what_wrong: what_wrong,
+      referrer: row[:user_came_from],
+      created_at: Date.parse(row[:creation_date]),
+      javascript_enabled: true,
+    )
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -25,13 +25,21 @@ describe ContentItem do
 
     another_item = create(:content_item, organisations: orgs, path: "/def",
       anonymous_contacts: [
+        create(:anonymous_contact, created_at: 60.days.ago),
         create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 80.days.ago),
+        create(:anonymous_contact, created_at: 90.days.ago),
       ]
     )
 
-    expect(ContentItem.summary).to contain_exactly(
+    expect(ContentItem.summary).to eq([
       { path: "/abc", last_7_days: 1, last_30_days: 2, last_90_days: 3 },
-      { path: "/def", last_7_days: 0, last_30_days: 0, last_90_days: 1 }
-    )
+      { path: "/def", last_7_days: 0, last_30_days: 0, last_90_days: 4 }
+    ])
+
+    expect(ContentItem.summary("last_90_days")).to eq([
+      { path: "/def", last_7_days: 0, last_30_days: 0, last_90_days: 4 },
+      { path: "/abc", last_7_days: 1, last_30_days: 2, last_90_days: 3 }
+    ])
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe ContentItem do
+  let(:orgs) { create_list(:organisation, 2) }
+
+  context "#for_organisation" do
+    it "should be filter only content items for that org" do
+      item1 = create(:content_item, organisations: [orgs[0]])
+      item2 = create(:content_item, organisations: [orgs[1]])
+      item3 = create(:content_item, organisations: [orgs[1]])
+
+      expect(ContentItem.for_organisation(orgs[1])).to contain_exactly(item2, item3)
+    end
+  end
+
+  it "calculates anonymous feedback counts for recent time intervals" do
+    item = create(:content_item, organisations: orgs, path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 5.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 100.days.ago),
+      ]
+    )
+
+    another_item = create(:content_item, organisations: orgs, path: "/def",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 70.days.ago),
+      ]
+    )
+
+    expect(ContentItem.summary).to contain_exactly(
+      { path: "/abc", last_7_days: 1, last_30_days: 2, last_90_days: 3 },
+      { path: "/def", last_7_days: 0, last_30_days: 0, last_90_days: 1 }
+    )
+  end
+end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -31,6 +31,8 @@ describe "Organisations that have feedback left on 'their' content" do
     create(:content_item, organisations: [ ukvi ], path: "/def",
       anonymous_contacts: [
         create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 75.days.ago),
+        create(:anonymous_contact, created_at: 80.days.ago),
       ]
     )
   end
@@ -41,7 +43,7 @@ describe "Organisations that have feedback left on 'their' content" do
     expect(json_response).to contain_exactly(hmrc_info, ukvi_info)
   end
 
-  it "provides feedback counts per org, sorted by the 7 day column" do
+  it "provides feedback counts per org, sorted by the 7 day column by default" do
     get_json "/anonymous-feedback/organisations/uk-visas-and-immigration"
 
     expect(json_response).to eq(
@@ -49,7 +51,20 @@ describe "Organisations that have feedback left on 'their' content" do
       "slug" => "uk-visas-and-immigration",
       "anonymous_feedback_counts" => [
         { "path" => "/abc", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 2 },
-        { "path" => "/def", "last_7_days" => 0, "last_30_days" => 0, "last_90_days" => 1 },
+        { "path" => "/def", "last_7_days" => 0, "last_30_days" => 0, "last_90_days" => 3 },
+      ]
+    )
+  end
+
+  it "provides feedback counts per org, sorted by the 90 day column if requested" do
+    get_json "/anonymous-feedback/organisations/uk-visas-and-immigration?ordering=last_90_days"
+
+    expect(json_response).to eq(
+      "title" => "UK Visas & Immigration",
+      "slug" => "uk-visas-and-immigration",
+      "anonymous_feedback_counts" => [
+        { "path" => "/def", "last_7_days" => 0, "last_30_days" => 0, "last_90_days" => 3 },
+        { "path" => "/abc", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 2 },
       ]
     )
   end


### PR DESCRIPTION
This is useful for being able to present FeedEx users with an overview
on which pages have had the most feedback left recently on them.

eg `/anonymous-feedback/organisations/hm-revenue-customs`:
```
{
  slug: "hm-revenue-customs",
  title: "HM Revenue & Customs",
  anonymous_feedback_counts: [
    {
      path: "/government-gateway",
      last_7_days: 0,
      last_30_days: 0,
      last_90_days: 1
    },
   ...
}
```

This is in support of https://tree.taiga.io/project/core-improvement-theme/us/12

@mikejustdoit note that I made a small renaming in the API interface (`results => anonymous_feedback_counts`) which will affect the corresponding Support app code.

/cc @boffbowsh @binaryberry @fofr 