### PR TITLE
Add rake task to import Organisations from Whitehall

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,6 +7,7 @@ class Organisation < ActiveRecord::Base
   validates :slug, presence: true
   validates :web_url, presence: true
   validates :title, presence: true
+  validates :govuk_status, presence: true
 
   def self.for_path(path)
     orgs_data = SupportApi::enhanced_content_api.organisations_for(path) || []

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,7 +7,6 @@ class Organisation < ActiveRecord::Base
   validates :slug, presence: true
   validates :web_url, presence: true
   validates :title, presence: true
-  validates :govuk_status, presence: true
 
   def self.for_path(path)
     orgs_data = SupportApi::enhanced_content_api.organisations_for(path) || []
@@ -15,6 +14,6 @@ class Organisation < ActiveRecord::Base
   end
 
   def as_json(options)
-    super(only: [:slug, :web_url, :title])
+    super(only: [:slug, :web_url, :title, :acronym, :govuk_status])
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,6 +22,10 @@ every 1.day, :at => '12:10 am' do
   rake "anonymous_feedback_deduplication:nightly"
 end
 
+every 1.day, :at => '12:50 am' do
+  rake "api_sync:import_organisations"
+end
+
 every 5.minutes, at: 3 do
   rake "anonymous_feedback_deduplication:recent"
 end

--- a/db/migrate/20150521102732_add_organisation_acronym_and_status.rb
+++ b/db/migrate/20150521102732_add_organisation_acronym_and_status.rb
@@ -1,0 +1,6 @@
+class AddOrganisationAcronymAndStatus < ActiveRecord::Migration
+  def change
+    add_column :organisations, :acronym, :string, limit: 255
+    add_column :organisations, :govuk_status, :string, limit: 255
+  end
+end

--- a/db/migrate/20150521140644_add_content_id_to_organisations.rb
+++ b/db/migrate/20150521140644_add_content_id_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddContentIdToOrganisations < ActiveRecord::Migration
+  def change
+    add_column :organisations, :content_id, :string, limit: 255
+    add_index :organisations, [:content_id], name: "index_organisations_on_content_id", using: :btree
+  end
+end

--- a/db/migrate/20150521144116_fill_organisation_content_ids.rb
+++ b/db/migrate/20150521144116_fill_organisation_content_ids.rb
@@ -1,0 +1,16 @@
+require 'gds_api/content_register'
+
+class FillOrganisationContentIds < ActiveRecord::Migration
+  def up
+    return if Organisation.count == 0
+
+    content_register = GdsApi::ContentRegister.new(Plek.new.find('content-register'))
+    organisation_map = Hash[content_register.entries("organisation").map do |org|
+      [org["base_path"].split('/')[-1], org["content_id"]]
+    end]
+
+    Organisation.all.each do |org|
+      org.update_attribute(:content_id, organisation_map[org.slug])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150521102732) do
+ActiveRecord::Schema.define(version: 20150521144116) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -60,6 +60,9 @@ ActiveRecord::Schema.define(version: 20150521102732) do
     t.datetime "updated_at",               null: false
     t.string   "acronym",      limit: 255
     t.string   "govuk_status", limit: 255
+    t.string   "content_id",   limit: 255
   end
+
+  add_index "organisations", ["content_id"], name: "index_organisations_on_content_id", using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518151221) do
+ActiveRecord::Schema.define(version: 20150521102732) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -53,11 +53,13 @@ ActiveRecord::Schema.define(version: 20150518151221) do
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
   create_table "organisations", force: :cascade do |t|
-    t.string   "slug",       limit: 255, null: false
-    t.string   "web_url",    limit: 255, null: false
-    t.string   "title",      limit: 255, null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "slug",         limit: 255, null: false
+    t.string   "web_url",      limit: 255, null: false
+    t.string   "title",        limit: 255, null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.string   "acronym",      limit: 255
+    t.string   "govuk_status", limit: 255
   end
 
 end

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -1,0 +1,68 @@
+require 'gds_api/organisations'
+
+class OrganisationImporter
+  def run
+    logger.info "Fetching all organisations from the Organisation API..."
+    organisations = organisations_api.organisations.with_subsequent_pages.to_a
+    logger.info "Loaded #{organisations.size} organisations"
+
+    organisations.each do |organisation|
+      create_or_update_organisation(organisation)
+    end
+
+    logger.info "Import complete"
+  end
+
+  private
+
+  def create_or_update_organisation(organisation_from_api)
+    organisation_attrs = {
+      :title => organisation_from_api.title,
+      :slug => organisation_from_api.details.slug,
+      :acronym => organisation_from_api.details.abbreviation,
+      :govuk_status => organisation_from_api.details.govuk_status,
+      :web_url => organisation_from_api.web_url,
+    }
+
+    slug = organisation_from_api.details.slug
+    existing_organisation = Organisation.find_by(slug: slug)
+
+    if existing_organisation.present?
+      existing_organisation.update_attributes(organisation_attrs)
+      logger.info "Updated #{existing_organisation.title}"
+    else
+      Organisation.create!(organisation_attrs)
+      logger.info "Created #{organisation_attrs[:title]}"
+    end
+  end
+
+  def logger
+    @logger ||= build_logger
+  end
+
+  def build_logger
+    output = case Rails.env
+             when "development" then STDOUT
+             when "test" then "/dev/null"
+             when "production" then Rails.root.join("log", "organisation_import.json.log")
+             end
+
+    Logger.new(output).tap {|logger|
+      logger.formatter = json_log_formatter if Rails.env.production?
+    }
+  end
+
+  def json_log_formatter
+    proc {|severity, datetime, progname, message|
+      {
+        "@message" => message,
+        "@tags" => ["cron", "rake"],
+        "@timestamp" => datetime.iso8601
+      }.to_json + "\n"
+    }
+  end
+
+  def organisations_api
+    @api_client ||= GdsApi::Organisations.new(Plek.current.find('whitehall-admin'))
+  end
+end

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -22,10 +22,11 @@ class OrganisationImporter
       :acronym => organisation_from_api.details.abbreviation,
       :govuk_status => organisation_from_api.details.govuk_status,
       :web_url => organisation_from_api.web_url,
+      :content_id => organisation_from_api.details.content_id,
     }
 
-    slug = organisation_from_api.details.slug
-    existing_organisation = Organisation.find_by(slug: slug)
+    content_id = organisation_from_api.details.content_id
+    existing_organisation = Organisation.find_by(content_id: content_id)
 
     if existing_organisation.present?
       existing_organisation.update_attributes(organisation_attrs)

--- a/lib/tasks/import_organisations.rake
+++ b/lib/tasks/import_organisations.rake
@@ -1,0 +1,8 @@
+require 'organisation_importer'
+
+namespace :api_sync do
+  desc "Imports all organisations from the Whitehall Organisations API"
+  task :import_organisations => :environment do
+    OrganisationImporter.new.run
+  end
+end

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -18,6 +18,8 @@ FactoryGirl.define do
     slug "ministry-of-magic"
     web_url { "https://www.gov.uk/government/organisations/#{slug}" }
     title "Ministry of Magic"
+    acronym "MOM"
+    govuk_status "live"
   end
 
   factory :content_item do

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
     title "Ministry of Magic"
     acronym "MOM"
     govuk_status "live"
+    sequence(:content_id) { |n| "content_id_#{n}" }
   end
 
   factory :content_item do

--- a/spec/lib/organisation_importer_spec.rb
+++ b/spec/lib/organisation_importer_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'organisation_importer'
+
+describe OrganisationImporter do
+  before do
+    organisations = organisations_api_response.map {|o|
+      OpenStruct.new(
+        title: o[:name],
+        details: OpenStruct.new(slug: o[:slug],
+                                govuk_status: "live",
+                                abbreviation: o[:abbreviation]),
+        web_url: "https://gov.uk/government/organisations/#{o[:slug]}"
+      )
+    }
+    stub_subsequent_pages = double(with_subsequent_pages: organisations)
+    allow_any_instance_of(GdsApi::Organisations).to receive(:organisations)
+      .and_return(stub_subsequent_pages)
+  end
+
+  let(:organisations_api_response) do
+    [{
+      slug: "ministry-of-magic",
+      name: "Ministry of Magic",
+      abbreviation: "MOM"
+    },{
+      slug: "ministry-of-fun",
+      name: "Ministry of Fun and Games",
+      abbreviation: "MOFG"
+    },{
+      slug: "ministry-of-unicorns",
+      name: "Ministry of Unicorns",
+      abbreviation: "MOU"
+    }]
+  end
+
+  before do
+    FactoryGirl.create(:organisation, title: "Ministry of Magic",
+                                      slug: "ministry-of-magic",
+                                      acronym: "MOM")
+    FactoryGirl.create(:organisation, title: "Ministry of Fun",
+                                      slug: "ministry-of-fun",
+                                      acronym: "MOF")
+    described_class.new.run
+  end
+
+  it "doesn't update an existing organisation if it hasn't changed" do
+    mom = Organisation.find_by(slug: "ministry-of-magic")
+    expect(mom.title).to eq("Ministry of Magic")
+    expect(mom.acronym).to eq("MOM")
+  end
+
+  it "update an existing organisation if it has changed" do
+    mof = Organisation.find_by(slug: "ministry-of-fun")
+    expect(mof.title).to eq("Ministry of Fun and Games")
+    expect(mof.acronym).to eq("MOFG")
+  end
+
+  it "creates a new organisation if it doesn't already exist" do
+    mou = Organisation.find_by(slug: "ministry-of-unicorns")
+    expect(mou.title).to eq("Ministry of Unicorns")
+    expect(mou.acronym).to eq("MOU")
+  end
+end

--- a/spec/lib/organisation_importer_spec.rb
+++ b/spec/lib/organisation_importer_spec.rb
@@ -8,7 +8,8 @@ describe OrganisationImporter do
         title: o[:name],
         details: OpenStruct.new(slug: o[:slug],
                                 govuk_status: "live",
-                                abbreviation: o[:abbreviation]),
+                                abbreviation: o[:abbreviation],
+                                content_id: o[:content_id]),
         web_url: "https://gov.uk/government/organisations/#{o[:slug]}"
       )
     }
@@ -21,42 +22,50 @@ describe OrganisationImporter do
     [{
       slug: "ministry-of-magic",
       name: "Ministry of Magic",
-      abbreviation: "MOM"
+      abbreviation: "MOM",
+      content_id: "abcdef"
     },{
-      slug: "ministry-of-fun",
+      slug: "ministry-of-fun-and-games",
       name: "Ministry of Fun and Games",
-      abbreviation: "MOFG"
+      abbreviation: "MOFG",
+      content_id: "123456"
     },{
       slug: "ministry-of-unicorns",
       name: "Ministry of Unicorns",
-      abbreviation: "MOU"
+      abbreviation: "MOU",
+      content_id: "c0ffee"
     }]
   end
 
   before do
     FactoryGirl.create(:organisation, title: "Ministry of Magic",
                                       slug: "ministry-of-magic",
-                                      acronym: "MOM")
+                                      acronym: "MOM",
+                                      content_id: "abcdef")
     FactoryGirl.create(:organisation, title: "Ministry of Fun",
                                       slug: "ministry-of-fun",
-                                      acronym: "MOF")
+                                      acronym: "MOF",
+                                      content_id: "123456")
     described_class.new.run
   end
 
   it "doesn't update an existing organisation if it hasn't changed" do
-    mom = Organisation.find_by(slug: "ministry-of-magic")
+    mom = Organisation.find_by(content_id: "abcdef")
+    expect(mom.slug).to eq("ministry-of-magic")
     expect(mom.title).to eq("Ministry of Magic")
     expect(mom.acronym).to eq("MOM")
   end
 
   it "update an existing organisation if it has changed" do
-    mof = Organisation.find_by(slug: "ministry-of-fun")
+    mof = Organisation.find_by(content_id: "123456")
+    expect(mof.slug).to eq("ministry-of-fun-and-games")
     expect(mof.title).to eq("Ministry of Fun and Games")
     expect(mof.acronym).to eq("MOFG")
   end
 
   it "creates a new organisation if it doesn't already exist" do
-    mou = Organisation.find_by(slug: "ministry-of-unicorns")
+    mou = Organisation.find_by(content_id: "c0ffee")
+    expect(mou.slug).to eq("ministry-of-unicorns")
     expect(mou.title).to eq("Ministry of Unicorns")
     expect(mou.acronym).to eq("MOU")
   end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -6,6 +6,8 @@ describe "Organisations that have feedback left on 'their' content" do
       "slug" => "hm-revenue-customs",
       "title" => "HM Revenue & Customs",
       "web_url" => "https://www.gov.uk/hmrc",
+      "acronym" => "HMRC",
+      "govuk_status" => "live"
     }
   }
 
@@ -14,6 +16,8 @@ describe "Organisations that have feedback left on 'their' content" do
       "slug" => "uk-visas-and-immigration",
       "title" => "UK Visas & Immigration",
       "web_url" => "https://www.gov.uk/ukvi",
+      "acronym" => "UKVI",
+      "govuk_status" => "live"
     }
   }
 


### PR DESCRIPTION
Steals an example from the needs_api. Will require a new set of
credentials creating for whitehall API and adding to the deployment
scripts.

Also added new acronym and govuk_status fields to organisations.

/cc @benilovj @mikejustdoit 