### PR TITLE
Add an index to speed up organisation summary page

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -20,6 +20,7 @@ class ContentItem < ActiveRecord::Base
       select(sum_column(from: midnight_last_night - 7.days, to: midnight_last_night, column_name: "last_7_days")).
       select(sum_column(from: midnight_last_night - 30.days, to: midnight_last_night, column_name: "last_30_days")).
       select(sum_column(from: midnight_last_night - 90.days, to: midnight_last_night, column_name: "last_90_days")).
+      where("`anonymous_contacts`.`created_at` > ?", midnight_last_night - 90.days).
       group("content_items.id").
       having("last_7_days + last_30_days + last_90_days > 0").
       order("#{ordering} #{ordering_mode}")

--- a/db/migrate/20150526095541_add_index_for_organisation_summary.rb
+++ b/db/migrate/20150526095541_add_index_for_organisation_summary.rb
@@ -1,0 +1,5 @@
+class AddIndexForOrganisationSummary < ActiveRecord::Migration
+  def change
+    add_index :anonymous_contacts, [:content_item_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150521144116) do
+ActiveRecord::Schema.define(version: 20150526095541) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20150521144116) do
     t.integer  "content_item_id",             limit: 4
   end
 
+  add_index "anonymous_contacts", ["content_item_id", "created_at"], name: "index_anonymous_contacts_on_content_item_id_and_created_at", using: :btree
   add_index "anonymous_contacts", ["created_at"], name: "index_anonymous_contacts_on_created_at", using: :btree
   add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>255}, using: :btree
 


### PR DESCRIPTION
We only count results in the last 90 days, so we should pre-filter them. Adding the index speeds this up on preview from ~7 seconds to under a second.