### PR TITLE
Add Export to CSV option for Feedback reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'mlanett-redis-lock', '0.2.6'
 gem "gds_zendesk", '1.0.4'
 gem "plek", "1.10.0"
 gem 'kaminari', "~> 0.16.3"
+gem 'user_agent_parser'
 
 group :development do
   gem 'spring', '1.3.5'

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ end
 group :test do
   gem 'factory_girl_rails', '4.5.0'
   gem 'webmock', '1.21.0'
+  gem 'fakefs', require: 'fakefs/safe'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    user_agent_parser (2.2.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -256,5 +257,6 @@ DEPENDENCIES
   spring (= 1.3.5)
   timecop (= 0.7.3)
   unicorn (= 4.9.0)
+  user_agent_parser
   webmock (= 1.21.0)
   whenever (= 0.9.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    fakefs (0.6.7)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     gds-api-adapters (18.6.0)
@@ -236,6 +237,7 @@ DEPENDENCIES
   ci_reporter (= 2.0.0)
   ci_reporter_rspec (= 1.0.0)
   factory_girl_rails (= 4.5.0)
+  fakefs
   gds-api-adapters (= 18.6.0)
   gds_zendesk (= 1.0.4)
   kaminari (~> 0.16.3)

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -1,0 +1,31 @@
+class AnonymousFeedback::ExportRequestsController < ApplicationController
+
+  def create
+    export_request = FeedbackExportRequest.new(export_request_params)
+
+    if export_request.save
+      GenerateFeedbackCsvWorker.perform_async(export_request.id)
+      render nothing: true, status: 202
+    else
+      render json: { "errors" => export_request.errors.to_a }, status: 422
+    end
+  end
+
+  def show
+    export_request = FeedbackExportRequest.find_by_id(params[:id])
+
+    if export_request
+      render json: {
+        "url" => export_request.url,
+        "ready" => !export_request.generated_at.nil?
+      }
+    else
+      head 404
+    end
+  end
+
+  private
+    def export_request_params
+      params.require(:export_request).permit(:filter_from, :filter_to, :path_prefix, :notification_email)
+    end
+end

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -26,6 +26,12 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   private
     def export_request_params
-      params.require(:export_request).permit(:filter_from, :filter_to, :path_prefix, :notification_email)
+      clean_params = params.require(:export_request).permit(:filter_from, :filter_to, :path_prefix, :notification_email)
+      {
+        filter_from: parse_date(clean_params[:filter_from]),
+        filter_to: parse_date(clean_params[:filter_to]),
+        path_prefix: clean_params[:path_prefix],
+        notification_email: clean_params[:notification_email]
+      }
     end
 end

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -16,7 +16,7 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
     if export_request
       render json: {
-        "url" => export_request.url,
+        "filename" => export_request.filename,
         "ready" => !export_request.generated_at.nil?
       }
     else

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -29,12 +29,4 @@ class AnonymousFeedbackController < ApplicationController
 
     render json: json
   end
-
-  def parse_date(date)
-    return nil if date.nil?
-    parsed_date = Date.parse(date)
-  rescue ArgumentError
-    return nil
-  end
-
 end

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -11,10 +11,7 @@ class AnonymousFeedbackController < ApplicationController
     from_date, to_date = [from_date, to_date].sort if from_date && to_date
 
     results = AnonymousContact.
-      only_actionable.
-      free_of_personal_info.
-      matching_path_prefix(params[:path_prefix]).
-      created_between_days(from_date || Date.new(1970), to_date || Date.today).
+      for_query_parameters(path_prefix: params[:path_prefix], from: from_date, to: to_date).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::API
+  def parse_date(date)
+    return nil if date.nil?
+    parsed_date = Date.parse(date)
+  rescue ArgumentError
+    return nil
+  end
 end

--- a/app/mailers/export_notification.rb
+++ b/app/mailers/export_notification.rb
@@ -1,0 +1,10 @@
+class ExportNotification < ActionMailer::Base
+  default from: "inside-government@digital.cabinet-office.gov.uk"
+
+  layout false
+
+  def notification_email(email, url)
+    @url = url
+    mail(to: email, subject: "[Feedback Explorer] Your feedback export is ready")
+  end
+end

--- a/app/mailers/export_notification.rb
+++ b/app/mailers/export_notification.rb
@@ -5,6 +5,6 @@ class ExportNotification < ActionMailer::Base
 
   def notification_email(email, url)
     @url = url
-    mail(to: email, subject: "[Feedback Explorer] Your feedback export is ready")
+    mail(to: email, subject: "[GOV.UK Feedback Explorer] Your feedback export is ready")
   end
 end

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -18,6 +18,7 @@ class AnonymousContact < ActiveRecord::Base
   }
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
+  scope :most_recent_last, -> { order("created_at ASC") }
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
 

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -21,6 +21,17 @@ class AnonymousContact < ActiveRecord::Base
   scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
 
+  scope :for_query_parameters, ->(options={}) do
+    path_prefix = options[:path_prefix] || "/"
+    from = options[:from] || Date.new(1970)
+    to = options[:to] || Date.today
+
+    only_actionable.
+      free_of_personal_info.
+      matching_path_prefix(path_prefix).
+      created_between_days(from, to)
+  end
+
   PAGE_SIZE = 50
   paginates_per PAGE_SIZE
 

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -19,11 +19,11 @@ class AnonymousContact < ActiveRecord::Base
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :most_recent_last, -> { order("created_at ASC") }
-  scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") }
+  scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") if path }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
 
   scope :for_query_parameters, ->(options={}) do
-    path_prefix = options[:path_prefix] || "/"
+    path_prefix = options[:path_prefix]
     from = options[:from] || Date.new(1970)
     to = options[:to] || Date.today
 

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -29,11 +29,7 @@ class FeedbackExportRequest < ActiveRecord::Base
   def generate_csv(io)
     csv = CSV.new(io)
     results.find_each do |row|
-      csv << [
-        row.created_at.strftime("%F %T"),
-        row.path,
-        row.referrer
-      ]
+      csv << FeedbackCsvRowPresenter.new(row).to_a
     end
     io
   end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -1,3 +1,6 @@
+require 'csv'
+require 'plek'
+
 class FeedbackExportRequest < ActiveRecord::Base
   validates :notification_email, :filter_to, :path_prefix, presence: true
 
@@ -33,5 +36,9 @@ class FeedbackExportRequest < ActiveRecord::Base
       ]
     end
     io
+  end
+
+  def url
+    Plek.find('support') + "/anonymous-feedback/export-requests/#{id}"
   end
 end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -1,0 +1,19 @@
+class FeedbackExportRequest < ActiveRecord::Base
+  validates :notification_email, :filter_to, :path_prefix, presence: true
+
+  before_validation on: :create do
+    self.filter_to ||= Date.today
+    self.path_prefix ||= "/"
+    generate_filename! if filename.nil?
+  end
+
+  def generate_filename!
+    parts = [
+      "feedex",
+      filter_from.nil? ? "0000-00-00" : filter_from.to_date.iso8601,
+      filter_to.nil? ? Date.today.iso8601 : filter_to.to_date.iso8601,
+    ]
+    parts += self.path_prefix.split("/").reject(&:blank?)
+    self.filename = "#{parts.join("_")}.csv"
+  end
+end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -22,4 +22,16 @@ class FeedbackExportRequest < ActiveRecord::Base
       for_query_parameters(path_prefix: path_prefix, from: filter_from, to: filter_to).
       most_recent_last
   end
+
+  def generate_csv(io)
+    csv = CSV.new(io)
+    results.find_each do |row|
+      csv << [
+        row.created_at.strftime("%F %T"),
+        row.path,
+        row.referrer
+      ]
+    end
+    io
+  end
 end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -36,6 +36,6 @@ class FeedbackExportRequest < ActiveRecord::Base
   end
 
   def url
-    Plek.find('support') + "/anonymous-feedback/export-requests/#{id}"
+    Plek.find('support') + "/anonymous_feedback/export_requests/#{id}"
   end
 end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -16,4 +16,10 @@ class FeedbackExportRequest < ActiveRecord::Base
     parts += self.path_prefix.split("/").reject(&:blank?)
     self.filename = "#{parts.join("_")}.csv"
   end
+
+  def results
+    AnonymousContact.
+      for_query_parameters(path_prefix: path_prefix, from: filter_from, to: filter_to).
+      most_recent_last
+  end
 end

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -28,6 +28,7 @@ class FeedbackExportRequest < ActiveRecord::Base
 
   def generate_csv(io)
     csv = CSV.new(io)
+    csv << FeedbackCsvRowPresenter::HEADER_ROW
     results.find_each do |row|
       csv << FeedbackCsvRowPresenter.new(row).to_a
     end

--- a/app/presenters/feedback_csv_row_presenter.rb
+++ b/app/presenters/feedback_csv_row_presenter.rb
@@ -3,6 +3,9 @@ require 'user_agent_parser'
 class FeedbackCsvRowPresenter
   attr_reader :row
 
+  HEADER_ROW = ["creation date", "path or service name", "feedback", "service satisfaction rating",
+                "browser name", "browser version", "browser platform", "user agent", "referrer", "type"]
+
   def initialize(row)
     @row = row
   end
@@ -17,7 +20,8 @@ class FeedbackCsvRowPresenter
       parsed_user_agent.version.to_s,
       parsed_user_agent.os.family,
       row.user_agent,
-      row.referrer
+      row.referrer,
+      row.type
     ]
   end
 

--- a/app/presenters/feedback_csv_row_presenter.rb
+++ b/app/presenters/feedback_csv_row_presenter.rb
@@ -6,6 +6,10 @@ class FeedbackCsvRowPresenter
   HEADER_ROW = ["creation date", "path or service name", "feedback", "service satisfaction rating",
                 "browser name", "browser version", "browser platform", "user agent", "referrer", "type"]
 
+  def self.parser
+    Thread.current[:user_agent_parser] ||= UserAgentParser::Parser.new
+  end
+
   def initialize(row)
     @row = row
   end
@@ -26,7 +30,7 @@ class FeedbackCsvRowPresenter
   end
 
   def parsed_user_agent
-    @parsed_user_agent ||= UserAgentParser.parse row.user_agent
+    @parsed_user_agent ||= self.class.parser.parse row.user_agent
   end
 
   def details_text

--- a/app/presenters/feedback_csv_row_presenter.rb
+++ b/app/presenters/feedback_csv_row_presenter.rb
@@ -1,0 +1,38 @@
+require 'user_agent_parser'
+
+class FeedbackCsvRowPresenter
+  attr_reader :row
+
+  def initialize(row)
+    @row = row
+  end
+
+  def to_a
+    [
+      row.created_at.strftime("%F %T"),
+      row.type == "service-feedback" ? row.slug : row.path,
+      details_text,
+      row.type == "service-feedback" ? row.service_satisfaction_rating.to_s : "",
+      parsed_user_agent.family,
+      parsed_user_agent.version.to_s,
+      parsed_user_agent.os.family,
+      row.user_agent,
+      row.referrer
+    ]
+  end
+
+  def parsed_user_agent
+    @parsed_user_agent ||= UserAgentParser.parse row.user_agent
+  end
+
+  def details_text
+    case row.type
+    when "problem-report"
+      "#{row.what_doing}\n#{row.what_wrong}"
+    when "service-feedback"
+      row.details
+    when "long-form-contact"
+      row.details
+    end
+  end
+end

--- a/app/views/export_notification/notification_email.text.erb
+++ b/app/views/export_notification/notification_email.text.erb
@@ -1,0 +1,5 @@
+Hi,
+
+The CSV you requested from the Feedback Explorer is available here:
+
+<%= @url%>

--- a/app/workers/generate_feedback_csv_worker.rb
+++ b/app/workers/generate_feedback_csv_worker.rb
@@ -1,7 +1,7 @@
 class GenerateFeedbackCsvWorker
   include Sidekiq::Worker
 
-  CSV_ROOT = "/data/uploads/feedback_explorer"
+  CSV_ROOT = "/data/uploads/support-api/csvs"
 
   def perform(*args)
     feedback_export_request = case args.first

--- a/app/workers/generate_feedback_csv_worker.rb
+++ b/app/workers/generate_feedback_csv_worker.rb
@@ -1,0 +1,28 @@
+class GenerateFeedbackCsvWorker
+  include Sidekiq::Worker
+
+  CSV_ROOT = "/data/uploads/feedback_explorer"
+
+  def perform(*args)
+    feedback_export_request = case args.first
+                              when Fixnum
+                                FeedbackExportRequest.find(args.first)
+                              when FeedbackExportRequest
+                                args.first
+                              end
+
+    file = self.class.create_file(feedback_export_request.filename)
+
+    feedback_export_request.generate_csv(file)
+    file.close
+
+    feedback_export_request.touch(:generated_at)
+
+    ExportNotification.notification_email(feedback_export_request.notification_email, feedback_export_request.url).deliver_now
+  end
+
+  def self.create_file name
+    FileUtils.mkdir_p(CSV_ROOT)
+    File.new(File.join(CSV_ROOT, name), "w")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,12 @@ Rails.application.routes.draw do
               controller: "problem_reports",
               as: "problem_report"
 
+    resources "export-requests",
+              only: [:create, :show],
+              format: false,
+              controller: "export_requests",
+              as: "export_request"
+
     get '/problem-reports/:date/totals',
         constraints: { date: /\d{4}-\d{2}-\d{2}/ },
         to: 'problem_reports#totals'

--- a/db/migrate/20150522151256_create_feedback_export_requests.rb
+++ b/db/migrate/20150522151256_create_feedback_export_requests.rb
@@ -1,0 +1,13 @@
+class CreateFeedbackExportRequests < ActiveRecord::Migration
+  def change
+    create_table :feedback_export_requests do |t|
+      t.string :notification_email
+      t.date :filter_from
+      t.date :filter_to
+      t.string :path_prefix
+      t.string :filename
+      t.datetime :generated_at, null: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150522151256_create_feedback_export_requests.rb
+++ b/db/migrate/20150522151256_create_feedback_export_requests.rb
@@ -1,7 +1,7 @@
 class CreateFeedbackExportRequests < ActiveRecord::Migration
   def change
     create_table :feedback_export_requests do |t|
-      t.string :notification_email
+      t.string :notification_email, null: false
       t.date :filter_from
       t.date :filter_to
       t.string :path_prefix

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,6 +53,17 @@ ActiveRecord::Schema.define(version: 20150526095541) do
   add_index "content_items_organisations", ["content_item_id"], name: "index_content_items_organisations_on_content_item_id", using: :btree
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
+  create_table "feedback_export_requests", force: :cascade do |t|
+    t.string   "notification_email", limit: 255
+    t.date     "filter_from"
+    t.date     "filter_to"
+    t.string   "path_prefix",        limit: 255
+    t.string   "filename",           limit: 255
+    t.datetime "generated_at"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
+
   create_table "organisations", force: :cascade do |t|
     t.string   "slug",         limit: 255, null: false
     t.string   "web_url",      limit: 255, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20150526095541) do
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
   create_table "feedback_export_requests", force: :cascade do |t|
-    t.string   "notification_email", limit: 255
+    t.string   "notification_email", limit: 255, null: false
     t.date     "filter_from"
     t.date     "filter_to"
     t.string   "path_prefix",        limit: 255

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
+  describe "#create" do
+    context "posted with valid parameters" do
+      before do
+        expect(GenerateFeedbackCsvWorker).to receive(:perform_async).once.with(instance_of(Fixnum))
+        post :create, export_request: {
+          filter_from: "2015-05-01", filter_to: "2015-06-01",
+          path_prefix: "/", notification_email: "foo@example.com"
+        }
+      end
+
+      subject { response }
+
+      it { is_expected.to be_accepted }
+    end
+
+    context "posted with invalid parameters" do
+      before do
+        expect(GenerateFeedbackCsvWorker).to receive(:perform_async).never
+        post :create, export_request: {
+          filter_from: "2015-05-01", filter_to: "2015-06-01",
+          path_prefix: "/"
+        }
+      end
+
+      subject { response }
+
+      it { is_expected.to be_unprocessable }
+    end
+  end
+
+  describe "#show" do
+    before { get :show, id: id }
+
+    subject { response }
+
+    context "requesting a non-existant export request" do
+      let(:id) { 1 }
+
+      it { is_expected.to be_not_found }
+    end
+
+    context "requesting a pending export request" do
+      let(:export_request) { create(:feedback_export_request) }
+      let(:id) { export_request.id }
+
+      it { is_expected.to be_success }
+
+      it "returns the URL" do
+        expect(JSON.parse(response.body)["url"]).to eq export_request.url
+      end
+
+      it "returns a status of not ready" do
+        expect(JSON.parse(response.body)["ready"]).to be false
+      end
+
+    end
+
+    context "requesting a processed export request" do
+      let(:export_request) { create(:feedback_export_request, generated_at: Time.now) }
+      let(:id) { export_request.id }
+
+      it { is_expected.to be_success }
+
+      it "returns the URL" do
+        expect(JSON.parse(response.body)["url"]).to eq export_request.url
+      end
+
+      it "returns a status of ready" do
+        expect(JSON.parse(response.body)["ready"]).to be true
+      end
+    end
+  end
+end

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
       it { is_expected.to be_success }
 
       it "returns the URL" do
-        expect(JSON.parse(response.body)["url"]).to eq export_request.url
+        expect(JSON.parse(response.body)["filename"]).to eq export_request.filename
       end
 
       it "returns a status of not ready" do
@@ -65,7 +65,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
       it { is_expected.to be_success }
 
       it "returns the URL" do
-        expect(JSON.parse(response.body)["url"]).to eq export_request.url
+        expect(JSON.parse(response.body)["filename"]).to eq export_request.filename
       end
 
       it "returns a status of ready" do

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -26,4 +26,11 @@ FactoryGirl.define do
   factory :content_item do
     path "/search"
   end
+
+  factory :feedback_export_request do
+    path_prefix "/"
+    filter_from Date.new(2015,5)
+    filter_to Date.new(2015,6)
+    notification_email "foo@example.com"
+  end
 end

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   factory :anonymous_contact, class: AnonymousContact do
     javascript_enabled true
     path "/vat-rates"
+    user_agent "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0;)"
+    referrer "http://www.example.com/foo"
 
     factory :problem_report, class: ProblemReport
 

--- a/spec/mailers/export_notification_spec.rb
+++ b/spec/mailers/export_notification_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ExportNotification, type: :mailer do
+  describe "notification_email" do
+    subject(:mail) { ExportNotification.notification_email("foo@example.com", "http://www.example.com/foo.csv") }
+
+    it "is sent from the no reply address" do
+      expect(mail.from).to eq ["inside-government@digital.cabinet-office.gov.uk"]
+    end
+
+    it "is sent to the correct recipient" do
+      expect(mail.to).to eq ["foo@example.com"]
+    end
+
+    it "contains the URL" do
+      expect(mail.body).to include "http://www.example.com/foo.csv"
+    end
+  end
+end

--- a/spec/mailers/previews/export_notification_preview.rb
+++ b/spec/mailers/previews/export_notification_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/export_notification
+class ExportNotificationPreview < ActionMailer::Preview
+
+end

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -129,7 +129,47 @@ describe AnonymousContact, :type => :model do
       it "returns the items that are included in the date interval" do
         expect(AnonymousContact.created_between_days(second_date.to_date, last_date.to_date).sort).to eq([@second_contact, @third_contact, @newest_contact])
       end
+    end
 
+    describe "for_query_parameters" do
+      let!(:contact_1) { contact(path: "/gov", created_at: Time.new(2015, 4, 10)) }
+      let!(:contact_2) { contact(path: "/courts", created_at: Time.new(2015, 5, 10)) }
+      let!(:personal_info) { contact(path: "/gov", details: "foo@example.com") }
+      let!(:not_actionable) { contact(path: "/gov", is_actionable: false, reason_why_not_actionable: "spam") }
+
+      subject { described_class.for_query_parameters(path_prefix: path_prefix,
+                                                     from: filter_from,
+                                                     to: filter_to).sort }
+
+      let(:path_prefix) { nil }
+      let(:filter_from) { nil }
+      let(:filter_to)   { nil }
+
+      context "with no restrictions" do
+        it { is_expected.to eq [contact_1, contact_2].sort }
+      end
+
+      context "with a restrictive from date" do
+        let(:filter_from) { Date.new 2015, 5 }
+        it { is_expected.to eq [contact_2] }
+      end
+
+      context "with a restrictive to date" do
+        let(:filter_to) { Date.new 2015, 5 }
+        it { is_expected.to eq [contact_1] }
+      end
+
+      context "with a restrictive date range" do
+        let(:filter_from) { Date.new 2015, 4 }
+        let(:filter_to) { Date.new 2015, 5 }
+
+        it { is_expected.to eq [contact_1] }
+      end
+
+      context "with a restrictive path prefix" do
+        let(:path_prefix) { "/gov" }
+        it { is_expected.to eq [contact_1] }
+      end
     end
   end
 

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -81,14 +81,22 @@ describe AnonymousContact, :type => :model do
   end
 
   context "scopes" do
-    it "can find urls beginning with the given path" do
-      a = contact(path: "/some-calculator/y/abc")
-      b = contact(path: "/some-calculator/y/abc/x")
-      c = contact(path: "/tax-disc")
+    describe "matching_path_prefix" do
+      let!(:a) { contact(path: "/some-calculator/y/abc") }
+      let!(:b) { contact(path: "/some-calculator/y/abc/x") }
+      let!(:c) { contact(path: "/tax-disc") }
 
-      result = AnonymousContact.matching_path_prefix("/some-calculator")
+      it "can find urls beginning with the given path" do
+        result = AnonymousContact.matching_path_prefix("/some-calculator")
 
-      expect(result).to contain_exactly(a, b)
+        expect(result).to contain_exactly(a, b)
+      end
+
+      it "is a no-op when given a nil path" do
+        result = AnonymousContact.matching_path_prefix(nil)
+
+        expect(result).to contain_exactly(a, b, c)
+      end
     end
 
     it "can return the results in reverse chronological order" do

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackExportRequest, type: :model do
+  before { Timecop.travel(Time.new(2015, 6, 1)) }
+
+  describe "setting defaults" do
+    subject(:instance) { described_class.new(notification_email: "user@example.com") }
+
+    before { instance.validate }
+
+    it "defaults the filename" do
+      expect(instance.filename).to eq "feedex_0000-00-00_2015-06-01.csv"
+    end
+
+    it "doesn't default the from date" do
+      expect(instance.filter_from).to be_nil
+    end
+
+    it "defaults the to date to today" do
+      expect(instance.filter_to).to eq Date.today
+    end
+  end
+
+  describe "#generate_filename!" do
+    let(:instance) { described_class.new(path_prefix: path_prefix,
+                                         filter_from: filter_from,
+                                         filter_to: filter_to) }
+    let(:path_prefix) { "/" }
+    let(:filter_from) { nil }
+    let(:filter_to)   { nil }
+
+    describe "the resulting filename" do
+      before { instance.generate_filename! }
+      subject(:filename) { instance.filename }
+
+      context "with no dates set" do
+        context "with a root path" do
+          let(:path_prefix) { "/" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01.csv" }
+        end
+
+        context "with a single-level path" do
+          let(:path_prefix) { "/gov_and_stuff" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff.csv" }
+        end
+
+        context "with a multi-level path" do
+          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_news-and-features.csv" }
+        end
+      end
+
+      context "with a from date set" do
+        let(:filter_from) { Date.new(2015, 4, 1) }
+
+        context "with a root path" do
+          let(:path_prefix) { "/" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-06-01.csv" }
+        end
+
+        context "with a single-level path" do
+          let(:path_prefix) { "/gov_and_stuff" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-06-01_gov_and_stuff.csv" }
+        end
+
+        context "with a multi-level path" do
+          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-06-01_gov_and_stuff_news-and-features.csv" }
+        end
+      end
+
+      context "with a to date set" do
+        let(:filter_to) { Date.new(2015, 5, 1) }
+
+        context "with a root path" do
+          let(:path_prefix) { "/" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-05-01.csv" }
+        end
+
+        context "with a single-level path" do
+          let(:path_prefix) { "/gov_and_stuff" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-05-01_gov_and_stuff.csv" }
+        end
+
+        context "with a multi-level path" do
+          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-05-01_gov_and_stuff_news-and-features.csv" }
+        end
+      end
+
+      context "with both dates set" do
+        let(:filter_from) { Date.new(2015, 4, 1) }
+        let(:filter_to) { Date.new(2015, 5, 1) }
+
+        context "with a root path" do
+          let(:path_prefix) { "/" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-05-01.csv" }
+        end
+
+        context "with a single-level path" do
+          let(:path_prefix) { "/gov_and_stuff" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-05-01_gov_and_stuff.csv" }
+        end
+
+        context "with a multi-level path" do
+          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-05-01_gov_and_stuff_news-and-features.csv" }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -121,4 +121,20 @@ RSpec.describe FeedbackExportRequest, type: :model do
       end
     end
   end
+
+  describe "#results" do
+    subject { described_class.new(filter_from: Date.new(2015, 4),
+                                  filter_to: Date.new(2015, 5),
+                                  path_prefix: "/").results }
+
+    it "uses the scope from the model with the correct parameters" do
+      contact = double("AnonymousContact")
+      expect(AnonymousContact).to receive(:for_query_parameters).with(from: Date.new(2015, 4),
+                                                                      to: Date.new(2015, 5),
+                                                                      path_prefix: "/").
+        and_return(double("scope", most_recent_last: [contact]))
+
+      expect(subject).to eq [contact]
+    end
+  end
 end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -150,12 +150,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
     subject(:generate_csv) { described_class.new.generate_csv(io) }
 
-    it "has 2 records" do
-      expect(subject.string.each_line.count).to eq 2
+    it "has 2 records plus a header" do
+      expect(subject.string.each_line.count).to eq 3
     end
 
     it "is parseable as a CSV" do
-      expect(CSV.parse(subject.string).count).to eq 2
+      expect(CSV.parse(subject.string).count).to eq 3
     end
 
     it "doesn't close the IO object" do
@@ -163,8 +163,9 @@ RSpec.describe FeedbackExportRequest, type: :model do
     end
 
     it "uses the FeedbackCsvRowPresenter to format the row" do
+      header = "creation date,path or service name,feedback,service satisfaction rating,browser name,browser version,browser platform,user agent,referrer,type"
       allow_any_instance_of(FeedbackCsvRowPresenter).to receive(:to_a).and_return(["a", "b", "c"])
-      expect(subject.string).to eq "a,b,c\na,b,c\n"
+      expect(subject.string).to eq "#{header}\na,b,c\na,b,c\n"
     end
   end
 end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -162,20 +162,9 @@ RSpec.describe FeedbackExportRequest, type: :model do
       expect(subject).to_not be_closed
     end
 
-    describe "row format" do
-      subject(:first_row) { CSV.parse(generate_csv.string)[0] }
-
-      it "has the time in ISO8601 format in UTC as the first column" do
-        expect(first_row[0]).to eq "2015-06-01 10:00:00"
-      end
-
-      it "has the path as the second column" do
-        expect(first_row[1]).to eq "/"
-      end
-
-      it "has the referrer as the third column" do
-        expect(first_row[2]).to eq "http://www.example.com/"
-      end
+    it "uses the FeedbackCsvRowPresenter to format the row" do
+      allow_any_instance_of(FeedbackCsvRowPresenter).to receive(:to_a).and_return(["a", "b", "c"])
+      expect(subject.string).to eq "a,b,c\na,b,c\n"
     end
   end
 end

--- a/spec/models/workers/generate_feedback_csv_worker_spec.rb
+++ b/spec/models/workers/generate_feedback_csv_worker_spec.rb
@@ -30,7 +30,7 @@ describe GenerateFeedbackCsvWorker, :type => :worker do
 
     it "populates the file with the CSV for the request" do
       described_class.new.perform(feedback_export_request)
-      expect(io.string.split("\n").count).to eq 1
+      expect(io.string.split("\n").count).to eq 2
     end
 
     it "closes the file" do

--- a/spec/models/workers/generate_feedback_csv_worker_spec.rb
+++ b/spec/models/workers/generate_feedback_csv_worker_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+describe GenerateFeedbackCsvWorker, :type => :worker do
+  describe ".create_file" do
+    include FakeFS::SpecHelpers
+
+    before { FakeFS.activate! }
+    after { FakeFS.deactivate! }
+
+    subject { GenerateFeedbackCsvWorker.create_file("foo.csv") }
+
+    it "creates the file in the configured root" do
+      subject
+      expect(File.exist?("/data/uploads/feedback_explorer/foo.csv")).to be true
+    end
+
+    it { is_expected.to_not be_closed }
+  end
+
+  describe "#perform" do
+    let(:feedback_export_request) { create(:feedback_export_request) }
+    let!(:io) do
+      StringIO.new.tap { |io| expect(described_class).to receive(:create_file).and_return(io) }
+    end
+
+    before do
+      create(:anonymous_contact, created_at: Time.new(2015, 5, 10))
+    end
+
+    it "populates the file with the CSV for the request" do
+      described_class.new.perform(feedback_export_request)
+      expect(io.string.split("\n").count).to eq 1
+    end
+
+    it "closes the file" do
+      described_class.new.perform(feedback_export_request)
+      expect(io).to be_closed
+    end
+
+    it "sends a notification email" do
+      mail = double
+      expect(mail).to receive(:deliver_now)
+      expect(ExportNotification).to receive(:notification_email).
+        with("foo@example.com", "http://support.dev.gov.uk/anonymous-feedback/export-requests/#{feedback_export_request.id}").
+        and_return(mail)
+      described_class.new.perform(feedback_export_request)
+    end
+
+    it "marks the request as generated" do
+      Timecop.freeze(Time.new(2015, 6, 1, 10)) do
+        described_class.new.perform(feedback_export_request)
+      end
+
+      expect(feedback_export_request.generated_at).to eq Time.new(2015, 6, 1, 10)
+    end
+  end
+end

--- a/spec/models/workers/generate_feedback_csv_worker_spec.rb
+++ b/spec/models/workers/generate_feedback_csv_worker_spec.rb
@@ -12,7 +12,7 @@ describe GenerateFeedbackCsvWorker, :type => :worker do
 
     it "creates the file in the configured root" do
       subject
-      expect(File.exist?("/data/uploads/feedback_explorer/foo.csv")).to be true
+      expect(File.exist?("/data/uploads/support-api/csvs/foo.csv")).to be true
     end
 
     it { is_expected.to_not be_closed }

--- a/spec/models/workers/generate_feedback_csv_worker_spec.rb
+++ b/spec/models/workers/generate_feedback_csv_worker_spec.rb
@@ -42,7 +42,7 @@ describe GenerateFeedbackCsvWorker, :type => :worker do
       mail = double
       expect(mail).to receive(:deliver_now)
       expect(ExportNotification).to receive(:notification_email).
-        with("foo@example.com", "http://support.dev.gov.uk/anonymous-feedback/export-requests/#{feedback_export_request.id}").
+        with("foo@example.com", "http://support.dev.gov.uk/anonymous_feedback/export_requests/#{feedback_export_request.id}").
         and_return(mail)
       described_class.new.perform(feedback_export_request)
     end

--- a/spec/presenters/feedback_csv_row_presenter_spec.rb
+++ b/spec/presenters/feedback_csv_row_presenter_spec.rb
@@ -22,7 +22,8 @@ describe FeedbackCsvRowPresenter do
           "9.0",
           "Windows Vista",
           row.user_agent,
-          "http://www.example.com/foo"
+          "http://www.example.com/foo",
+          "problem-report"
         ]
       end
     end
@@ -40,7 +41,8 @@ describe FeedbackCsvRowPresenter do
           "9.0",
           "Windows Vista",
           row.user_agent,
-          "http://www.example.com/foo"
+          "http://www.example.com/foo",
+          "service-feedback"
         ]
       end
     end
@@ -58,7 +60,8 @@ describe FeedbackCsvRowPresenter do
           "9.0",
           "Windows Vista",
           row.user_agent,
-          "http://www.example.com/foo"
+          "http://www.example.com/foo",
+          "long-form-contact"
         ]
       end
     end

--- a/spec/presenters/feedback_csv_row_presenter_spec.rb
+++ b/spec/presenters/feedback_csv_row_presenter_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe FeedbackCsvRowPresenter do
+  subject(:instance) { described_class.new(row) }
+  let(:problem_report) { build(:problem_report, created_at: Time.utc(2015,4), what_doing: "Finding the thing", what_wrong: "Couldn't find the thing\nThanks") }
+  let(:service_feedback) { build(:service_feedback, created_at: Time.utc(2015,4), details: "It was good\nWell done", service_satisfaction_rating: 3) }
+  let(:long_form_contact) { build(:long_form_contact, created_at: Time.utc(2015,4), details: "It was really good\nReally.\nGood job") }
+
+  describe "#to_a" do
+    subject { instance.to_a }
+
+    context "for a problem report" do
+      let(:row) { problem_report }
+
+      it "presents the correct columns" do
+        expect(subject).to eq [
+          "2015-04-01 00:00:00",
+          row.path,
+          "#{row.what_doing}\n#{row.what_wrong}",
+          "",
+          "IE",
+          "9.0",
+          "Windows Vista",
+          row.user_agent,
+          "http://www.example.com/foo"
+        ]
+      end
+    end
+
+    context "for service feedback" do
+      let(:row) { service_feedback }
+
+      it "presents the correct columns" do
+        expect(subject).to eq [
+          "2015-04-01 00:00:00",
+          row.slug,
+          row.details,
+          "3",
+          "IE",
+          "9.0",
+          "Windows Vista",
+          row.user_agent,
+          "http://www.example.com/foo"
+        ]
+      end
+    end
+
+    context "for long form contact" do
+      let(:row) { long_form_contact }
+
+      it "presents the correct columns" do
+        expect(subject).to eq [
+          "2015-04-01 00:00:00",
+          row.path,
+          row.details,
+          "",
+          "IE",
+          "9.0",
+          "Windows Vista",
+          row.user_agent,
+          "http://www.example.com/foo"
+        ]
+      end
+    end
+  end
+
+  describe "#details_text" do
+    subject { instance.details_text }
+    context "for a problem report" do
+      let(:row) { problem_report }
+
+      it "is what_doing and what_wrong joined with a newline" do
+        expect(subject).to eq "Finding the thing\nCouldn't find the thing\nThanks"
+      end
+    end
+
+    context "for service feedback" do
+      let(:row) { service_feedback }
+
+      it { is_expected.to eq("It was good\nWell done") }
+    end
+
+    context "for long form contact" do
+      let(:row) { long_form_contact }
+
+      it { is_expected.to eq("It was really good\nReally.\nGood job") }
+    end
+  end
+end


### PR DESCRIPTION
Takes a date range, a path prefix and an email address to notify as parameters. It then enqueues a Sidekiq job which generates the CSV and dumps it in `/data/uploads/feedback_explorer`. This is a mounted NFS path and will be available to both frontend and backend boxes. The link in the email will eventually make the support app ask nginx to send the correct CSV to the user using the `X-Accel-Redirect` header.

Work to come to support this on the front end:
- [x] Support app work to add an Export to CSV button, and a controller endpoint to serve the generated CSV
- [x] Puppet work to add the `/data/uploads/feedback_explorer` location to nginx.
- [x] Api adapter work to add the new endpoints
- [x] puppet work to ensure the directory exists and is writable

/cc @benilovj @evilstreak @bradleywright 