### PR TITLE
Allow filtering feedback by Organisation

### DIFF
--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -26,11 +26,13 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   private
     def export_request_params
-      clean_params = params.require(:export_request).permit(:filter_from, :filter_to, :path_prefix, :notification_email)
+      clean_params = params.require(:export_request).permit(:from, :to, :path_prefix, :notification_email)
       {
-        filter_from: parse_date(clean_params[:filter_from]),
-        filter_to: parse_date(clean_params[:filter_to]),
-        path_prefix: clean_params[:path_prefix],
+        filters: {
+          from: parse_date(clean_params[:from]),
+          to: parse_date(clean_params[:to]),
+          path_prefix: clean_params[:path_prefix],
+        },
         notification_email: clean_params[:notification_email]
       }
     end

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -26,12 +26,14 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   private
     def export_request_params
-      clean_params = params.require(:export_request).permit(:from, :to, :path_prefix, :notification_email)
+      permitted_params = %i(from to path_prefix organisation notification_email)
+      clean_params = params.require(:export_request).permit(*permitted_params)
       {
         filters: {
           from: parse_date(clean_params[:from]),
           to: parse_date(clean_params[:to]),
           path_prefix: clean_params[:path_prefix],
+          organisation_slug: clean_params[:organisation]
         },
         notification_email: clean_params[:notification_email]
       }

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,7 +1,6 @@
 class AnonymousFeedbackController < ApplicationController
   def index
-    organisation = Organisation.find_by(slug: params[:organisation_slug])
-    unless organisation || params[:path_prefix]
+    unless params[:organisation_slug].present? || params[:path_prefix].present?
       head :bad_request
       return
     end
@@ -11,17 +10,14 @@ class AnonymousFeedbackController < ApplicationController
 
     from_date, to_date = [from_date, to_date].sort if from_date && to_date
 
-    scope = AnonymousContact.
-      for_query_parameters(path_prefix: params[:path_prefix], from: from_date, to: to_date).
+    results = AnonymousContact.
+      for_query_parameters(path_prefix: params[:path_prefix],
+                           organisation_slug: params[:organisation_slug],
+                           from: from_date,
+                           to: to_date).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)
-
-    results = if organisation
-                organisation.anonymous_contacts.merge(scope)
-              else
-                scope
-              end
 
     json = {
       results: results,

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,6 +1,7 @@
 class AnonymousFeedbackController < ApplicationController
   def index
-    unless params[:path_prefix].present?
+    organisation = Organisation.find_by(slug: params[:organisation_slug])
+    unless organisation || params[:path_prefix]
       head :bad_request
       return
     end
@@ -10,11 +11,17 @@ class AnonymousFeedbackController < ApplicationController
 
     from_date, to_date = [from_date, to_date].sort if from_date && to_date
 
-    results = AnonymousContact.
+    scope = AnonymousContact.
       for_query_parameters(path_prefix: params[:path_prefix], from: from_date, to: to_date).
       most_recent_first.
       page(params[:page]).
       per(AnonymousContact::PAGE_SIZE)
+
+    results = if organisation
+                organisation.anonymous_contacts.merge(scope)
+              else
+                scope
+              end
 
     json = {
       results: results,

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -19,7 +19,7 @@ class AnonymousContact < ActiveRecord::Base
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :most_recent_last, -> { order("created_at ASC") }
-  scope :matching_path_prefix, ->(path) { where("path LIKE ?", path + "%") if path }
+  scope :matching_path_prefix, ->(path) { where("anonymous_contacts.path LIKE ?", path + "%") if path }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
 
   scope :for_query_parameters, ->(options={}) do

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -30,11 +30,16 @@ class AnonymousContact < ActiveRecord::Base
     path_prefix = options[:path_prefix]
     from = options[:from] || Date.new(1970)
     to = options[:to] || Date.today
+    organisation_slug = options[:organisation_slug]
 
-    only_actionable.
+    query = only_actionable.
       free_of_personal_info.
-      matching_path_prefix(path_prefix).
       created_between_days(from, to)
+
+    query = query.matching_path_prefix(path_prefix) if path_prefix
+    query = query.for_organisation_slug(organisation_slug) if organisation_slug
+
+    query
   end
 
   PAGE_SIZE = 50

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -4,6 +4,9 @@ require 'duplicate_detector'
 class AnonymousContact < ActiveRecord::Base
   before_save :detect_personal_information
 
+  belongs_to :content_item
+  has_many :organisations, through: :content_item
+
   validates :referrer, url: true, length: { maximum: 2048 }, allow_nil: true
   validates :path,     url: true, length: { maximum: 2048 }, presence: true
   validates :user_agent, length: { maximum: 2048 }
@@ -21,6 +24,7 @@ class AnonymousContact < ActiveRecord::Base
   scope :most_recent_last, -> { order("created_at ASC") }
   scope :matching_path_prefix, ->(path) { where("anonymous_contacts.path LIKE ?", path + "%") if path }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
+  scope :for_organisation_slug, -> (slug) { joins(:organisations).where(organisations: {slug: slug}) }
 
   scope :for_query_parameters, ->(options={}) do
     path_prefix = options[:path_prefix]

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -8,7 +8,7 @@ class ContentItem < ActiveRecord::Base
 
   scope :for_organisation, ->(organisation) {
     joins(:organisations).
-    where("organisations.id = ?", organisation.id)
+    where(organisations: { id: organisation.id})
   }
 
   def self.summary(ordering="last_7_days")

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -8,7 +8,6 @@ class FeedbackExportRequest < ActiveRecord::Base
 
   before_validation on: :create do
     filters[:to] ||= Date.today
-    filters[:path_prefix] ||= "/"
     generate_filename! if filename.nil?
   end
 
@@ -18,7 +17,8 @@ class FeedbackExportRequest < ActiveRecord::Base
       filters[:from].nil? ? "0000-00-00" : filters[:from].to_date.iso8601,
       filters[:to].nil? ? Date.today.iso8601 : filters[:to].to_date.iso8601,
     ]
-    parts += filters[:path_prefix].split("/").reject(&:blank?)
+    parts += filters[:path_prefix].split("/").reject(&:blank?) if filters[:path_prefix].present?
+    parts << filters[:organisation_slug] if filters[:organisation_slug].present?
     self.filename = "#{parts.join("_")}.csv"
   end
 

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -2,27 +2,29 @@ require 'csv'
 require 'plek'
 
 class FeedbackExportRequest < ActiveRecord::Base
-  validates :notification_email, :filter_to, :path_prefix, presence: true
+  validates :notification_email, :filters, presence: true
+
+  serialize :filters, Hash
 
   before_validation on: :create do
-    self.filter_to ||= Date.today
-    self.path_prefix ||= "/"
+    filters[:to] ||= Date.today
+    filters[:path_prefix] ||= "/"
     generate_filename! if filename.nil?
   end
 
   def generate_filename!
     parts = [
       "feedex",
-      filter_from.nil? ? "0000-00-00" : filter_from.to_date.iso8601,
-      filter_to.nil? ? Date.today.iso8601 : filter_to.to_date.iso8601,
+      filters[:from].nil? ? "0000-00-00" : filters[:from].to_date.iso8601,
+      filters[:to].nil? ? Date.today.iso8601 : filters[:to].to_date.iso8601,
     ]
-    parts += self.path_prefix.split("/").reject(&:blank?)
+    parts += filters[:path_prefix].split("/").reject(&:blank?)
     self.filename = "#{parts.join("_")}.csv"
   end
 
   def results
     AnonymousContact.
-      for_query_parameters(path_prefix: path_prefix, from: filter_from, to: filter_to).
+      for_query_parameters(filters).
       most_recent_last
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,6 +3,7 @@ require 'content_api/enhanced_content_api'
 class Organisation < ActiveRecord::Base
   has_and_belongs_to_many :content_items
   has_many :problem_reports, through: :content_items
+  has_many :anonymous_contacts, through: :content_items
 
   validates :slug, presence: true
   validates :web_url, presence: true

--- a/app/models/problem_report.rb
+++ b/app/models/problem_report.rb
@@ -5,8 +5,6 @@ class ProblemReport < AnonymousContact
   validates :what_doing, length: { maximum: 2 ** 16 }
   validates :what_wrong, length: { maximum: 2 ** 16 }
 
-  belongs_to :content_item
-
   scope :totals_for, ->(date) {
     where(created_at: date.beginning_of_day..date.end_of_day).
       only_actionable.

--- a/db/migrate/20150604140707_serialise_export_filters.rb
+++ b/db/migrate/20150604140707_serialise_export_filters.rb
@@ -1,0 +1,36 @@
+class SerialiseExportFilters < ActiveRecord::Migration
+  def up
+    add_column :feedback_export_requests, :filters, :text
+
+    FeedbackExportRequest.reset_column_information
+
+    FeedbackExportRequest.all.each do |req|
+      filters = {}
+      filters[:from] = req.filter_from if req.filter_from
+      filters[:to] = req.filter_to if req.filter_to
+      filters[:path_prefix] = req.path_prefix if req.path_prefix
+      req.update(filters: filters)
+    end
+
+    remove_column :feedback_export_requests, :filter_from
+    remove_column :feedback_export_requests, :filter_to
+    remove_column :feedback_export_requests, :path_prefix
+  end
+
+  def down
+    add_column :feedback_export_requests, :path_prefix, :string
+    add_column :feedback_export_requests, :filter_to, :date
+    add_column :feedback_export_requests, :filter_from, :date
+
+    FeedbackExportRequest.reset_column_information
+
+    FeedbackExportRequest.all.each do |req|
+      req.filter_from = req.filters[:from] if req.filters[:from]
+      req.filter_to = req.filters[:to] if req.filters[:to]
+      req.path_prefix = req.filters[:path_prefix] if req.filters[:path_prefix]
+      req.save
+    end
+
+    remove_column :feedback_export_requests, :filters
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526095541) do
+ActiveRecord::Schema.define(version: 20150604140707) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -54,14 +54,12 @@ ActiveRecord::Schema.define(version: 20150526095541) do
   add_index "content_items_organisations", ["organisation_id"], name: "index_content_items_organisations_on_organisation_id", using: :btree
 
   create_table "feedback_export_requests", force: :cascade do |t|
-    t.string   "notification_email", limit: 255, null: false
-    t.date     "filter_from"
-    t.date     "filter_to"
-    t.string   "path_prefix",        limit: 255
+    t.string   "notification_email", limit: 255
     t.string   "filename",           limit: 255
     t.datetime "generated_at"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.text     "filters",            limit: 65535
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
       before do
         expect(GenerateFeedbackCsvWorker).to receive(:perform_async).once.with(instance_of(Fixnum))
         post :create, export_request: {
-          filter_from: "2015-05-01", filter_to: "2015-06-01",
+          from: "2015-05-01", to: "2015-06-01",
           path_prefix: "/", notification_email: "foo@example.com"
         }
       end
@@ -20,7 +20,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
       before do
         expect(GenerateFeedbackCsvWorker).to receive(:perform_async).never
         post :create, export_request: {
-          filter_from: "2015-05-01", filter_to: "2015-06-01",
+          from: "2015-05-01", to: "2015-06-01",
           path_prefix: "/"
         }
       end

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -39,6 +39,37 @@ describe AnonymousFeedbackController do
       )
     end
 
+    describe "filter by organisation" do
+      let(:hmrc) { create(:organisation, slug: 'hm-revenue-customs') }
+      let(:ukvi) { create(:organisation, slug: 'uk-visas-and-immigration') }
+      let(:ukvi_content) { create(:content_item, organisations: [ukvi]) }
+      let(:hmrc_content) { create(:content_item, organisations: [hmrc]) }
+      let!(:hmrc_problem_reports) { create_list(:problem_report, 3, path: "/abc", content_item: hmrc_content) }
+      let!(:ukvi_problem_reports) { create_list(:problem_report, 2, content_item: ukvi_content) }
+
+      it "returns only feedback belonging to that organisation" do
+        get :index, organisation_slug: "hm-revenue-customs"
+
+        expect(json_response["total_count"]).to eq(3)
+        ids_of_returned_problem_reports = json_response["results"].map {|r| r["id"]}.sort
+        expect(ids_of_returned_problem_reports).to eq(hmrc_problem_reports.map(&:id).sort)
+      end
+
+      it "returns an error when the org doesn't exist" do
+        get :index, organisation_slug: "made-up-org"
+        expect(response).to have_http_status(400)
+      end
+
+      it "combines with path filters" do
+        create(:problem_report, path: "/xyz", content_item: hmrc_content)
+
+        get :index, organisation_slug: "hm-revenue-customs", path_prefix: "/xyz"
+
+        expect(json_response["total_count"]).to eq(1)
+        expect(json_response["results"].first["path"]).to eq("/xyz")
+      end
+    end
+
     describe "from and to parameters" do
       let(:first_date)  { Time.new(2014, 01, 01).utc }
       let(:second_date) { Time.new(2014, 10, 31).utc }

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AnonymousFeedbackController do
   describe "#index" do
-    it "is a bad request with no `path_prefix`" do
+    it "is a bad request with no `path_prefix` or `organisation_slug`" do
       get :index
       expect(response).to have_http_status(400)
     end
@@ -55,9 +55,16 @@ describe AnonymousFeedbackController do
         expect(ids_of_returned_problem_reports).to eq(hmrc_problem_reports.map(&:id).sort)
       end
 
-      it "returns an error when the org doesn't exist" do
-        get :index, organisation_slug: "made-up-org"
-        expect(response).to have_http_status(400)
+      context "if an org doesn't exist" do
+        before { get :index, organisation_slug: "made-up-org" }
+        it "doesn't return an error" do
+          expect(response).to have_http_status(200)
+        end
+
+        it "returns no results" do
+          expect(json_response["total_count"]).to eq(0)
+          expect(json_response["results"]).to be_empty
+        end
       end
 
       it "combines with path filters" do

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -30,9 +30,9 @@ FactoryGirl.define do
   end
 
   factory :feedback_export_request do
-    path_prefix "/"
-    filter_from Date.new(2015,5)
-    filter_to Date.new(2015,6)
+    filters Hash.new(path_prefix: "/",
+                     from: Date.new(2015,5),
+                     to: Date.new(2015,6))
     notification_email "foo@example.com"
   end
 end

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -146,30 +146,30 @@ describe AnonymousContact, :type => :model do
       let!(:not_actionable) { contact(path: "/gov", is_actionable: false, reason_why_not_actionable: "spam") }
 
       subject { described_class.for_query_parameters(path_prefix: path_prefix,
-                                                     from: filter_from,
-                                                     to: filter_to).sort }
+                                                     from: from,
+                                                     to: to).sort }
 
       let(:path_prefix) { nil }
-      let(:filter_from) { nil }
-      let(:filter_to)   { nil }
+      let(:from) { nil }
+      let(:to)   { nil }
 
       context "with no restrictions" do
         it { is_expected.to eq [contact_1, contact_2].sort }
       end
 
       context "with a restrictive from date" do
-        let(:filter_from) { Date.new 2015, 5 }
+        let(:from) { Date.new 2015, 5 }
         it { is_expected.to eq [contact_2] }
       end
 
       context "with a restrictive to date" do
-        let(:filter_to) { Date.new 2015, 5 }
+        let(:to) { Date.new 2015, 5 }
         it { is_expected.to eq [contact_1] }
       end
 
       context "with a restrictive date range" do
-        let(:filter_from) { Date.new 2015, 4 }
-        let(:filter_to) { Date.new 2015, 5 }
+        let(:from) { Date.new 2015, 4 }
+        let(:to) { Date.new 2015, 5 }
 
         it { is_expected.to eq [contact_1] }
       end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -13,21 +13,23 @@ RSpec.describe FeedbackExportRequest, type: :model do
     end
 
     it "doesn't default the from date" do
-      expect(instance.filter_from).to be_nil
+      expect(instance.filters[:from]).to be_nil
     end
 
     it "defaults the to date to today" do
-      expect(instance.filter_to).to eq Date.today
+      expect(instance.filters[:to]).to eq Date.today
     end
   end
 
   describe "#generate_filename!" do
-    let(:instance) { described_class.new(path_prefix: path_prefix,
-                                         filter_from: filter_from,
-                                         filter_to: filter_to) }
+    let(:instance) do
+      described_class.new(filters: {path_prefix: path_prefix,
+                                    from: from,
+                                    to: to })
+    end
     let(:path_prefix) { "/" }
-    let(:filter_from) { nil }
-    let(:filter_to)   { nil }
+    let(:from) { nil }
+    let(:to)   { nil }
 
     describe "the resulting filename" do
       before { instance.generate_filename! }
@@ -54,7 +56,7 @@ RSpec.describe FeedbackExportRequest, type: :model do
       end
 
       context "with a from date set" do
-        let(:filter_from) { Date.new(2015, 4, 1) }
+        let(:from) { Date.new(2015, 4, 1) }
 
         context "with a root path" do
           let(:path_prefix) { "/" }
@@ -76,7 +78,7 @@ RSpec.describe FeedbackExportRequest, type: :model do
       end
 
       context "with a to date set" do
-        let(:filter_to) { Date.new(2015, 5, 1) }
+        let(:to) { Date.new(2015, 5, 1) }
 
         context "with a root path" do
           let(:path_prefix) { "/" }
@@ -98,8 +100,8 @@ RSpec.describe FeedbackExportRequest, type: :model do
       end
 
       context "with both dates set" do
-        let(:filter_from) { Date.new(2015, 4, 1) }
-        let(:filter_to) { Date.new(2015, 5, 1) }
+        let(:from) { Date.new(2015, 4, 1) }
+        let(:to) { Date.new(2015, 5, 1) }
 
         context "with a root path" do
           let(:path_prefix) { "/" }
@@ -123,9 +125,11 @@ RSpec.describe FeedbackExportRequest, type: :model do
   end
 
   describe "#results" do
-    subject { described_class.new(filter_from: Date.new(2015, 4),
-                                  filter_to: Date.new(2015, 5),
-                                  path_prefix: "/").results }
+    subject do
+      described_class.new(filters: {from: Date.new(2015, 4),
+                                    to: Date.new(2015, 5),
+                                    path_prefix: "/"}).results
+    end
 
     it "uses the scope from the model with the correct parameters" do
       contact = double("AnonymousContact")

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe FeedbackExportRequest, type: :model do
     let(:instance) do
       described_class.new(filters: {path_prefix: path_prefix,
                                     from: from,
-                                    to: to })
+                                    to: to,
+                                    organisation_slug: organisation_slug })
     end
-    let(:path_prefix) { "/" }
+    let(:path_prefix) { nil }
     let(:from) { nil }
     let(:to)   { nil }
+    let(:organisation_slug) { nil }
 
     describe "the resulting filename" do
       before { instance.generate_filename! }
@@ -53,6 +55,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
           it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_news-and-features.csv" }
         end
+
+        context "with an organisation slug" do
+          let(:organisation_slug) { "hm-revenue-customs" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_hm-revenue-customs.csv" }
+        end
       end
 
       context "with a from date set" do
@@ -75,6 +83,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
           it { is_expected.to eq "feedex_2015-04-01_2015-06-01_gov_and_stuff_news-and-features.csv" }
         end
+
+        context "with an organisation slug" do
+          let(:organisation_slug) { "hm-revenue-customs" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-06-01_hm-revenue-customs.csv" }
+        end
       end
 
       context "with a to date set" do
@@ -96,6 +110,13 @@ RSpec.describe FeedbackExportRequest, type: :model do
           let(:path_prefix) { "/gov_and_stuff/news-and-features" }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-05-01_gov_and_stuff_news-and-features.csv" }
+        end
+
+
+        context "with an organisation slug" do
+          let(:organisation_slug) { "hm-revenue-customs" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-05-01_hm-revenue-customs.csv" }
         end
       end
 
@@ -120,6 +141,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01_gov_and_stuff_news-and-features.csv" }
         end
+
+        context "with an organisation slug" do
+          let(:organisation_slug) { "hm-revenue-customs" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-05-01_hm-revenue-customs.csv" }
+        end
       end
     end
   end
@@ -128,14 +155,16 @@ RSpec.describe FeedbackExportRequest, type: :model do
     subject do
       described_class.new(filters: {from: Date.new(2015, 4),
                                     to: Date.new(2015, 5),
-                                    path_prefix: "/"}).results
+                                    path_prefix: "/",
+                                    organisation_slug: "hm-revenue-customs"}).results
     end
 
     it "uses the scope from the model with the correct parameters" do
       contact = double("AnonymousContact")
       expect(AnonymousContact).to receive(:for_query_parameters).with(from: Date.new(2015, 4),
                                                                       to: Date.new(2015, 5),
-                                                                      path_prefix: "/").
+                                                                      path_prefix: "/",
+                                                                      organisation_slug: "hm-revenue-customs").
         and_return(double("scope", most_recent_last: [contact]))
 
       expect(subject).to eq [contact]


### PR DESCRIPTION
Taiga: https://tree.taiga.io/project/core-improvement-theme/us/52

Problem Reports are categorised by Organisation, so they should be filterable by Organisation too. Passing an `organisation_slug` parameter to the API will only return Problem Reports associated with that Organisation. Service Feedback and Long Form Contacts aren't currently associated with an org, so they will never be returned.

This includes some refactoring to support multiple future types of filter for CSVs, by storing the filter parameters as a serialised hash in the database.