### PR TITLE
Refactor organisation-related endpoints

### DIFF
--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -1,10 +1,5 @@
 module AnonymousFeedback
   class OrganisationsController < ApplicationController
-    def index
-      organisations = Organisation.order(:slug)
-      render json: organisations
-    end
-
     def show
       if %w(path last_7_days last_30_days last_90_days).include? params[:ordering]
         ordering = params[:ordering]

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -7,6 +7,12 @@ module AnonymousFeedback
         ordering = "last_7_days"
       end
       organisation = Organisation.find_by(slug: params[:slug])
+
+      if organisation.nil?
+        render nothing: true, status: :not_found
+        return
+      end
+
       anonymous_feedback_counts = ContentItem.
         for_organisation(organisation).
         summary(ordering)

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,0 +1,15 @@
+class OrganisationsController < ApplicationController
+  def index
+    organisations = Organisation.order(:slug)
+    render json: organisations
+  end
+
+  def show
+    organisation = Organisation.find_by(slug: params[:slug])
+    if organisation
+      render json: organisation
+    else
+      render nothing: true, status: :not_found
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,11 +38,15 @@ Rails.application.routes.draw do
         constraints: { period: /\d{4}-\d{2}(-\d{2})?/ },
         to: 'problem_reports#index'
 
-    resources 'organisations',
-        only: [:index, :show],
-        format: false,
-        param: :slug
+    get '/organisations/:slug', to: "organisations#show"
   end
+
+  # TODO: Remove this endpoint once the support app has been repointed to /organisations
+  get '/anonymous-feedback/organisations', to: "organisations#index"
+  resources :organisations,
+            only: [:index, :show],
+            format: false,
+            param: :slug
 
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }
 end

--- a/spec/controllers/anonymous_feedback/organisations_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/organisations_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe AnonymousFeedback::OrganisationsController, type: :controller do
+  describe "#show" do
+    let(:slug) { "ministry-of-magic" }
+    let(:ordering) { "last_30_days" }
+
+    subject do
+      get :show, slug: slug, ordering: ordering
+      response
+    end
+
+    context "with a valid organisation" do
+      let!(:organisation) { create(:organisation) }
+
+      it { is_expected.to be_success }
+
+      context "with a valid ordering" do
+        it "returns the ordered summary for the organisation" do
+          scope = double("scope")
+          expect(ContentItem).to receive(:for_organisation).with(organisation)
+            .and_return(scope)
+          expect(scope).to receive(:summary).with("last_30_days").and_return([{
+            "path" => "/", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 3}])
+
+          expect(JSON.parse(subject.body)).to eq(
+            "slug" => "ministry-of-magic",
+            "title" => "Ministry of Magic",
+            "anonymous_feedback_counts" => [
+              {"path" => "/", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 3}
+            ]
+          )
+        end
+      end
+
+      context "with invalid ordering" do
+        let(:ordering) { "foobar" }
+
+        it "returns the default ordered summary for the organisation" do
+          scope = double("scope")
+          expect(ContentItem).to receive(:for_organisation).with(organisation)
+            .and_return(scope)
+          expect(scope).to receive(:summary).with("last_7_days").and_return([{
+            "path" => "/", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 3}])
+
+          expect(JSON.parse(subject.body)).to eq(
+            "slug" => "ministry-of-magic",
+            "title" => "Ministry of Magic",
+            "anonymous_feedback_counts" => [
+              {"path" => "/", "last_7_days" => 1, "last_30_days" => 2, "last_90_days" => 3}
+            ]
+          )
+        end
+      end
+    end
+end

--- a/spec/controllers/anonymous_feedback/organisations_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/organisations_controller_spec.rb
@@ -53,4 +53,9 @@ RSpec.describe AnonymousFeedback::OrganisationsController, type: :controller do
         end
       end
     end
+
+    context "with an invalid organisation" do
+      it { is_expected.to be_not_found }
+    end
+  end
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe OrganisationsController, type: :controller do
+  describe "#index" do
+    before do
+      create :organisation, title: "Ministry of Magic"
+      create :organisation, title: "Department of Fair Dos"
+    end
+
+    it "renders an ordered json list of organisations" do
+      get :index
+      expect(JSON.parse(response.body)).to eq [
+        {
+          "title" => "Department of Fair Dos",
+          "slug" => "department-of-fair-dos",
+          "acronym" => "DOFD",
+          "govuk_status" => "live",
+          "web_url" => "https://www.gov.uk/government/organisations/department-of-fair-dos"
+        },
+        {
+          "title" => "Ministry of Magic",
+          "slug" => "ministry-of-magic",
+          "acronym" => "MOM",
+          "govuk_status" => "live",
+          "web_url" => "https://www.gov.uk/government/organisations/ministry-of-magic"
+        }
+      ]
+    end
+  end
+
+  describe "#show" do
+    context "for a valid organisation" do
+      let!(:organisation) { create :organisation }
+
+      it "renders the organisation as json" do
+        get :show, slug: "ministry-of-magic"
+        expect(JSON.parse(response.body)).to eq(
+          "title" => "Ministry of Magic",
+          "slug" => "ministry-of-magic",
+          "acronym" => "MOM",
+          "govuk_status" => "live",
+          "web_url" => "https://www.gov.uk/government/organisations/ministry-of-magic"
+        )
+      end
+    end
+
+    context "for an invalid organisation" do
+      it "returns a 404" do
+        get :show, slug: "ministry-of-magic"
+
+        expect(response).to be_not_found
+      end
+    end
+  end
+end

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -17,10 +17,10 @@ FactoryGirl.define do
   end
 
   factory :organisation do
-    slug "ministry-of-magic"
+    slug { title.parameterize }
     web_url { "https://www.gov.uk/government/organisations/#{slug}" }
     title "Ministry of Magic"
-    acronym "MOM"
+    acronym { title.split.map { |s| s[0] }.join.upcase }
     govuk_status "live"
     sequence(:content_id) { |n| "content_id_#{n}" }
   end


### PR DESCRIPTION
Move the Organisation index into a separate controller as it’s
unrelated to anonymous feedback
Add an Organisation show action to retrieve the title etc for a single
organisation
Add a spec for the org summary action

Backwards-compatible for the support app as the `/anonymous-feedback/organisations` endpoint still works, but should be removed.