### PR TITLE
Remove feedback records with invalid dates

### DIFF
--- a/db/migrate/20150611133227_remove_blank_dates.rb
+++ b/db/migrate/20150611133227_remove_blank_dates.rb
@@ -1,0 +1,14 @@
+class RemoveBlankDates < ActiveRecord::Migration
+  def up
+    records = AnonymousContact.where("created_at = '0000-00-00 00:00:00' OR
+                                      updated_at = '0000-00-00 00:00:00'")
+
+    # At time of writing, there were only 3 of these.
+    if records.size > 10
+      Rails.logger.warn "Migration would have removed #{records.size} records. " +
+       "Cowardly refusing to do anything."
+    else
+      records.each(&:destroy)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150604140707) do
+ActiveRecord::Schema.define(version: 20150611133227) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255


### PR DESCRIPTION
There was a short scan of GOV.UK in November 2012 using the [Vega](https://subgraph.com/vega/) vulnerability scanning tool.
This populated some feedback forms with various maliciously crafted strings
and submitted them. There doesn’t seem to be any side effects from
this, except that somehow created_at and updated_at dates were set to
blank for just 3 of the records.

The information provided is meaningless, so this migration simply
deletes the records.

It will find other records with blank (not NULL) dates and delete them,
but as a safeguard it’ll just refuse to do anything if it finds more
than 10 records.

This work is needed because attempting to import the data into Postgres
in this state will make it fail the NOT NULL constraints on these
columns.