### PR TITLE
Require Rails environment to be set up for sync task

### DIFF
--- a/lib/tasks/synchronise_mysql_to_postgresql.rake
+++ b/lib/tasks/synchronise_mysql_to_postgresql.rake
@@ -1,4 +1,4 @@
-task "db:sync" do
+task "db:sync" => :environment do
   BATCH_SIZE = 2500
 
   mysql = Sequel.connect(ActiveRecord::Base.configurations["mysql_#{Rails.env}"])


### PR DESCRIPTION
The sync task relies on `Rails.env` being set, which is populated in the Rails boot process

/cc @benilovj 