### PR TITLE
Add index on path using PostgreSQL's varchar_pattern operator class

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,11 +15,11 @@ Bundler.require(*Rails.groups)
 
 module SupportApi
   def self.postgresql?
-    ENV["SUPPORT_API_DB_TYPE"] == "postgresql"
+    ENV["SUPPORT_API_DB_TYPE"].blank? || ENV["SUPPORT_API_DB_TYPE"] == "postgresql"
   end
 
   def self.mysql?
-    ENV["SUPPORT_API_DB_TYPE"].blank? || ENV["SUPPORT_API_DB_TYPE"] == "mysql"
+    ENV["SUPPORT_API_DB_TYPE"] == "mysql"
   end
 
   class Application < Rails::Application

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-<% db_type = ENV["SUPPORT_API_DB_TYPE"].nil? ? "mysql" : ENV["SUPPORT_API_DB_TYPE"] %>
+<% db_type = ENV["SUPPORT_API_DB_TYPE"].nil? ? "postgresql" : ENV["SUPPORT_API_DB_TYPE"] %>
 
 mysql_default: &mysql_default
   adapter: mysql2

--- a/db/migrate/20150623151655_add_path_index_with_varchar_pattern_ops.rb
+++ b/db/migrate/20150623151655_add_path_index_with_varchar_pattern_ops.rb
@@ -1,0 +1,19 @@
+class AddPathIndexWithVarcharPatternOps < ActiveRecord::Migration
+  def up
+    remove_index :anonymous_contacts, :path
+
+    if SupportApi.postgresql?
+      execute <<-SQL
+        CREATE INDEX index_anonymous_contacts_on_path
+        ON anonymous_contacts USING btree (path varchar_pattern_ops);
+      SQL
+    else
+      add_index :anonymous_contacts, [:path], length: {path: 128}
+    end
+  end
+
+  def down
+    remove_index :anonymous_contacts, [:path]
+    add_index :anonymous_contacts, [:path], length: {path: 128}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150612130729) do
+ActiveRecord::Schema.define(version: 20150623151655) do
 
   create_table "anonymous_contacts", force: :cascade do |t|
     t.string   "type",                        limit: 255
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20150612130729) do
   add_index "anonymous_contacts", ["content_item_id", "created_at"], name: "index_anonymous_contacts_on_content_item_id_and_created_at", using: :btree
   add_index "anonymous_contacts", ["created_at", "path"], name: "index_anonymous_contacts_on_created_at_and_path", length: {"created_at"=>nil, "path"=>128}, using: :btree
   add_index "anonymous_contacts", ["created_at"], name: "index_anonymous_contacts_on_created_at", using: :btree
-  add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>255}, using: :btree
+  add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", length: {"path"=>128}, using: :btree
 
   create_table "content_items", force: :cascade do |t|
     t.string   "path",       limit: 2048, null: false

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -280,7 +280,7 @@ CREATE INDEX index_anonymous_contacts_on_created_at_and_path ON anonymous_contac
 -- Name: index_anonymous_contacts_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_anonymous_contacts_on_path ON anonymous_contacts USING btree (path);
+CREATE INDEX index_anonymous_contacts_on_path ON anonymous_contacts USING btree (path varchar_pattern_ops);
 
 
 --
@@ -356,4 +356,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150604140707');
 INSERT INTO schema_migrations (version) VALUES ('20150611133227');
 
 INSERT INTO schema_migrations (version) VALUES ('20150612130729');
+
+INSERT INTO schema_migrations (version) VALUES ('20150623151655');
 


### PR DESCRIPTION
This index will be used in the case where a user is filtering for feedback over a large time period, probably encompassing all feedback. In this case, PostgreSQL will rightly ignore the index. The previous index on `path` was not able to be used with `LIKE` filters, so we add `varchar_pattern_ops`, same as the main composite index.