### PR TITLE
Deduplicate organisations

### DIFF
--- a/db/migrate/20150915134640_deduplicate_organisations.rb
+++ b/db/migrate/20150915134640_deduplicate_organisations.rb
@@ -1,0 +1,66 @@
+class DeduplicateOrganisations < ActiveRecord::Migration
+  class Organisation < ActiveRecord::Base
+    has_and_belongs_to_many :content_items
+  end
+
+  def up
+    remove_duplicate_organisations
+    deduplicate_content_items_organisations_join_table
+  end
+
+  def down
+    remove_index :content_items_organisations, name: :index_content_items_organisations_unique
+    remove_index :organisations, :content_id
+    add_index :organisations, :content_id, name: :index_organisations_on_content_id, using: :btree
+  end
+
+private
+  def remove_duplicate_organisations
+    Organisation.all.group_by(&:content_id).each do |content_id, organisations|
+      if organisations.count > 1
+        first_organisation = organisations.min_by(&:id)
+        dupe_organisations = organisations - [first_organisation]
+
+        # Point any content_items for the duplicate organisations at the
+        # first_organisation. Note that this could create duplicate rows, which
+        # we deduplicate later.
+        execute """
+            UPDATE content_items_organisations
+            SET organisation_id=#{first_organisation.id}
+            WHERE organisation_id IN (#{dupe_organisations.map(&:id).join(",")})
+        """
+
+        dupe_organisations.each(&:delete)
+      end
+    end
+
+    # Change the index on organisations content_id to be unique
+    remove_index :organisations, name: :index_organisations_on_content_id
+    add_index :organisations, :content_id, unique: true
+  end
+
+  def deduplicate_content_items_organisations_join_table
+    # Create a new table to contain the deduplicated relationship
+    execute """
+        CREATE TABLE content_items_organisations_deduped (LIKE content_items_organisations)
+    """
+
+    # Copy the unique rows into the new table
+    execute """
+        INSERT INTO content_items_organisations_deduped
+        SELECT DISTINCT content_item_id, organisation_id
+        FROM content_items_organisations
+    """
+
+    # Rename the new table over the old. Have to drop it first to achieve this.
+    drop_table :content_items_organisations
+    rename_table :content_items_organisations_deduped, :content_items_organisations
+
+    # Add a unique index so that duplicate join rows aren't created in future
+    add_index :content_items_organisations, [:content_item_id, :organisation_id], name: :index_content_items_organisations_unique, unique: true
+  end
+
+  def execute(sql)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,7 +3,8 @@
 --
 
 SET statement_timeout = 0;
-SET client_encoding = 'SQL_ASCII';
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
@@ -284,24 +285,17 @@ CREATE INDEX index_anonymous_contacts_on_path ON anonymous_contacts USING btree 
 
 
 --
--- Name: index_content_items_organisations_on_content_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_content_items_organisations_unique; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_content_items_organisations_on_content_item_id ON content_items_organisations USING btree (content_item_id);
-
-
---
--- Name: index_content_items_organisations_on_organisation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_content_items_organisations_on_organisation_id ON content_items_organisations USING btree (organisation_id);
+CREATE UNIQUE INDEX index_content_items_organisations_unique ON content_items_organisations USING btree (content_item_id, organisation_id);
 
 
 --
 -- Name: index_organisations_on_content_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_organisations_on_content_id ON organisations USING btree (content_id);
+CREATE UNIQUE INDEX index_organisations_on_content_id ON organisations USING btree (content_id);
 
 
 --
@@ -358,4 +352,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150611133227');
 INSERT INTO schema_migrations (version) VALUES ('20150612130729');
 
 INSERT INTO schema_migrations (version) VALUES ('20150623151655');
+
+INSERT INTO schema_migrations (version) VALUES ('20150915134640');
 

--- a/lib/tasks/import_organisations.rake
+++ b/lib/tasks/import_organisations.rake
@@ -1,8 +1,11 @@
 require 'organisation_importer'
+require 'distributed_lock'
 
 namespace :api_sync do
   desc "Imports all organisations from the Whitehall Organisations API"
   task :import_organisations => :environment do
-    OrganisationImporter.new.run
+    DistributedLock.new('import_organisations').lock do
+      OrganisationImporter.new.run
+    end
   end
 end


### PR DESCRIPTION
The cron job to import organisations now only runs on a single machine, instead of every machine concurrently. This lead to a race condition where duplicate organisations could be created. This also deduplicates the organisations in the database