### PR TITLE
Owning organisation(s) for each problem report now updated each time one comes in

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -4,8 +4,6 @@ class ContentItem < ActiveRecord::Base
   has_many :anonymous_contacts
   validates :path, presence: true
 
-  before_create :fetch_organisations, unless: ->(content_item) { content_item.organisations.present? }
-
   scope :for_organisation, ->(organisation) {
     joins(:organisations).
     where(organisations: { id: organisation.id})
@@ -35,6 +33,11 @@ class ContentItem < ActiveRecord::Base
       map { |row| integers_for_sum_columns(row) }
   end
 
+  def fetch_organisations
+    self.organisations = Organisation.for_path(path)
+    save!
+  end
+
 private
   def self.sum_column(options)
     "SUM(
@@ -42,10 +45,6 @@ private
             ELSE 0
             END
         )"
-  end
-
-  def fetch_organisations
-    self.organisations = Organisation.for_path(path)
   end
 
   def self.integers_for_sum_columns(row)

--- a/app/workers/content_item_enrichment_worker.rb
+++ b/app/workers/content_item_enrichment_worker.rb
@@ -4,6 +4,7 @@ class ContentItemEnrichmentWorker
   def perform(problem_report_id)
     problem_report = ProblemReport.find(problem_report_id)
     problem_report.content_item = ContentItem.where(path: problem_report.content_item_path).first_or_create!
+    problem_report.content_item.fetch_organisations
     problem_report.save!
   end
 end

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -6,22 +6,22 @@ describe ContentItemEnrichmentWorker do
 
   subject { ContentItemEnrichmentWorker.new }
 
-  context "for a problem report that relates to a non-existent piece of content" do
-    let(:problem_report) { create(:problem_report, path: "/non-existent-page") }
+  context "for a problem report about a piece of content we can't determine the organisation for" do
+    let(:problem_report) { create(:problem_report, path: "/unknown-org-page") }
 
     before do
-      content_api_does_not_have_an_artefact("non-existent-page")
+      content_api_does_not_have_an_artefact("unknown-org-page")
       subject.perform(problem_report.id)
       problem_report.reload
     end
 
-    it "creates a content item for the problem report" do
-      expect(problem_report.content_item.path).to eq("/non-existent-page")
+    it "assigns the problem_report to GDS" do
+      expect(problem_report.content_item.path).to eq("/unknown-org-page")
       expect(problem_report.content_item.organisations.first["title"]).to eq("Government Digital Service")
     end
   end
 
-  context "for a problem report that relates to an existing piece of content" do
+  context "for a problem report about a piece of content we know the organisation of" do
     let(:hmrc) { Organisation.where(slug: 'hm-revenue-customs').first }
     let(:vat_rates_content_api_response) {
       api_response = artefact_for_slug("vat-rates").tap do |hash|
@@ -46,9 +46,58 @@ describe ContentItemEnrichmentWorker do
       problem_report.reload
     end
 
-    it "creates a content item for the problem report" do
+    it "assigns the problem report to the organisation" do
       expect(problem_report.content_item.path).to eq("/vat-rates")
       expect(problem_report.content_item.organisations).to eq([hmrc])
+    end
+  end
+
+  context "for a problem report about a piece of content whose organisation has changed" do
+    let(:hmrc) { Organisation.where(slug: 'hm-revenue-customs').first }
+    let(:aaib) { Organisation.where(slug: 'air-accidents-investigation-branch').first }
+    let(:vat_rates_content_api_response) {
+      api_response = artefact_for_slug("vat-rates").tap do |hash|
+        hash["tags"] = [
+          {
+            slug: "hm-revenue-customs",
+            web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+            title: "HM Revenue & Customs",
+            details: {
+              type: "organisation",
+            }
+          }
+        ]
+      end
+    }
+    let(:vat_rates_content_api_response_new) {
+      api_response = artefact_for_slug("vat-rates").tap do |hash|
+        hash["tags"] = [
+          {
+            slug: "air-accidents-investigation-branch",
+            web_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
+            title: "aaib",
+            details: {
+              type: "organisation",
+            }
+          }
+        ]
+      end
+    }
+
+    let(:problem_report) { create(:problem_report, path: "/vat-rates") }
+
+    before do
+      content_api_has_an_artefact("vat-rates", vat_rates_content_api_response)
+      subject.perform(problem_report.id)
+      problem_report.reload
+    end
+
+    it "assigns the problem report to the new organisation" do
+      expect(problem_report.content_item.organisations).to eq([hmrc])
+      content_api_has_an_artefact("vat-rates", vat_rates_content_api_response_new)
+      subject.perform(problem_report.id)
+      problem_report.reload
+      expect(problem_report.content_item.organisations).to eq([aaib])
     end
   end
 end

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -15,13 +15,13 @@ describe ContentItemEnrichmentWorker do
       problem_report.reload
     end
 
-    it "creates a content item for the problem report, but no orgs" do
+    it "creates a content item for the problem report" do
       expect(problem_report.content_item.path).to eq("/non-existent-page")
       expect(problem_report.content_item.organisations.first["title"]).to eq("Government Digital Service")
     end
   end
 
-  context "for a problem report that relates to a piece of mainstream content" do
+  context "for a problem report that relates to an existing piece of content" do
     let(:hmrc) { Organisation.where(slug: 'hm-revenue-customs').first }
     let(:vat_rates_content_api_response) {
       api_response = artefact_for_slug("vat-rates").tap do |hash|
@@ -46,7 +46,7 @@ describe ContentItemEnrichmentWorker do
       problem_report.reload
     end
 
-    it "creates a content item for the problem report, but no orgs" do
+    it "creates a content item for the problem report" do
       expect(problem_report.content_item.path).to eq("/vat-rates")
       expect(problem_report.content_item.organisations).to eq([hmrc])
     end

--- a/spec/requests/problem_reports_spec.rb
+++ b/spec/requests/problem_reports_spec.rb
@@ -102,6 +102,11 @@ javascript_enabled: true
   end
 
   context "fetching" do
+    let!(:gds) {
+      create(:organisation,
+        slug: "government-digital-service"
+      )
+    }
     let!(:problem_report) {
       create(:problem_report,
         what_wrong: "A",
@@ -110,7 +115,7 @@ javascript_enabled: true
         referrer: "https://www.gov.uk/browse",
         user_agent: "Safari",
         created_at: Date.new(2015,02,02),
-        content_item: create(:content_item, path: "/help"),
+        content_item: create(:content_item, path: "/help", organisations: [gds]),
       )
     }
 


### PR DESCRIPTION
Before this change, the owning organisation for each piece of content was only determined when the content was first seen. This meant that for content where the owning org was updated, the changes were never picked up.

https://trello.com/c/WK0EqQUl/100-content-in-feedex-incorrectly-appearing-for-dvsa-filter-medium

/cc @jamiecobbett @boffbowsh @binaryberry 