### PR TITLE
Bump gds_zendesk gem, no longer set the date fields on Zendesk tickets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'unicorn', '4.9.0'
 gem 'gds-api-adapters', '20.1.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mlanett-redis-lock', '0.2.6'
-gem "gds_zendesk", '1.0.5'
+gem "gds_zendesk", '2.0.0'
 gem "plek", "1.10.0"
 gem 'kaminari', "~> 0.16.3"
 gem 'user_agent_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
-    gds_zendesk (1.0.5)
+    gds_zendesk (2.0.0)
       null_logger (= 0.0.1)
       zendesk_api (= 1.8.0)
     globalid (0.3.5)
@@ -240,7 +240,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.5.0)
   fakefs
   gds-api-adapters (= 20.1.1)
-  gds_zendesk (= 1.0.5)
+  gds_zendesk (= 2.0.0)
   kaminari (~> 0.16.3)
   logstasher (= 0.6.2)
   mlanett-redis-lock (= 0.2.6)

--- a/lib/zendesk/ticket.rb
+++ b/lib/zendesk/ticket.rb
@@ -1,5 +1,4 @@
 require 'erb'
-require 'gds_zendesk/field_mappings'
 
 module Zendesk
   class Ticket
@@ -12,10 +11,6 @@ module Zendesk
         subject: subject,
         requester: { "locale_id" => 1, "email" => requester[:email], "name" => requester[:name] },
         collaborators: collaborator_emails,
-        fields: [
-                  { "id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date],  "value" => needed_by_date },
-                  { "id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => not_before_date }
-                ],
         tags: tags,
         comment: { "body" => rendered_body }
       }
@@ -26,14 +21,6 @@ module Zendesk
       path_to_template = File.join(Rails.root, 'app', 'zendesk_tickets', "#{template_name}.erb")
       template = ERB.new(File.read(path_to_template))
       template.result(binding)
-    end
-
-    def needed_by_date
-      nil
-    end
-
-    def not_before_date
-      nil
     end
 
     def collaborator_emails


### PR DESCRIPTION
The custom date fields on Zendesk tickets are no longer set
for other Zendesk tickets, and in this app these fields were
never populated anyway, so we can safely not send them to Zendesk.

I've tested this by:
- pushing this branch to Preview
- raising a problem report
- making sure that the ticket lands in Zendesk successfully

/cc @binaryberry @boffbowsh 