### PR TITLE
Make pagination more performant

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -15,6 +15,7 @@ class AnonymousFeedbackController < ApplicationController
 
     json[:from_date] = dates[0] if dates[0]
     json[:to_date] = dates[1] if dates[1]
+    json[:results_limited] = results_limited if results_limited
 
     render json: json
   end
@@ -38,6 +39,10 @@ class AnonymousFeedbackController < ApplicationController
 
   def total_count
     @total_count ||= scope.limit(AnonymousContact::MAX_PAGES * AnonymousContact::PAGE_SIZE).count
+  end
+
+  def results_limited
+    total_count >= AnonymousContact::PAGE_SIZE * AnonymousContact::MAX_PAGES
   end
 
   def pages

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -5,31 +5,57 @@ class AnonymousFeedbackController < ApplicationController
       return
     end
 
-    from_date = parse_date(params[:from])
-    to_date = parse_date(params[:to])
-
-    from_date, to_date = [from_date, to_date].sort if from_date && to_date
-
-    results = AnonymousContact.
-      for_query_parameters(path_prefix: params[:path_prefix],
-                           organisation_slug: params[:organisation_slug],
-                           from: from_date,
-                           to: to_date).
-      most_recent_first.
-      page(params[:page]).
-      per(AnonymousContact::PAGE_SIZE)
-
     json = {
       results: results,
-      total_count: results.total_count,
-      current_page: results.current_page,
-      pages: results.total_pages,
+      total_count: total_count,
+      current_page: current_page,
+      pages: pages,
       page_size: AnonymousContact::PAGE_SIZE,
     }
 
-    json[:from_date] = from_date if from_date
-    json[:to_date] = to_date if to_date
+    json[:from_date] = dates[0] if dates[0]
+    json[:to_date] = dates[1] if dates[1]
 
     render json: json
+  end
+
+  private
+
+  def scope
+    AnonymousContact.
+      for_query_parameters(path_prefix: params[:path_prefix],
+                           organisation_slug: params[:organisation_slug],
+                           from: dates[0],
+                           to: dates[1]).
+      most_recent_first
+  end
+
+  def dates
+    [parse_date(params[:from]), parse_date(params[:to])].tap do |dates|
+      dates.sort! if params[:from] && params[:to]
+    end
+  end
+
+  def total_count
+    @total_count ||= scope.limit(AnonymousContact::MAX_PAGES * AnonymousContact::PAGE_SIZE).count
+  end
+
+  def pages
+    total_count == 0 ? 0 : (total_count / AnonymousContact::PAGE_SIZE.to_f).ceil
+  end
+
+  def current_page
+    pages == 0 || params[:page].to_i < 1 ? 1 : params[:page].to_i
+  end
+
+  def results
+    if current_page > pages
+      []
+    else
+      offset = (current_page - 1) * AnonymousContact::PAGE_SIZE
+      limit = AnonymousContact::PAGE_SIZE
+
+      scope.offset(offset).limit(limit)
+    end
   end
 end

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -42,6 +42,7 @@ class AnonymousContact < ActiveRecord::Base
     query
   end
 
+  MAX_PAGES = 200
   PAGE_SIZE = 50
   paginates_per PAGE_SIZE
 

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -78,7 +78,8 @@ describe AnonymousFeedbackController do
           "total_count" => 100,
           "current_page" => 3,
           "pages" => 2,
-          "results" => []
+          "results" => [],
+          "results_limited" => true
         )
       end
     end


### PR DESCRIPTION
For queries that will return a lot of results, fetching the initial result count is very expensive (20s for over 3 million results).

Luckily, Rails can do a `COUNT` with `LIMIT` in PostgreSQL. If you specify a limit as part of a scope then call `.count`, it will generate SQL like this:

```sql
SELECT COUNT(count_column) FROM 
  (SELECT 1 AS count_column FROM "anonymous_contacts" 
   WHERE path LIKE '/done/vehicle-tax%' 
   LIMIT 10000) subquery_for_count;
```

This returns in around 20ms on a dev VM for a query that would return 3 million rows if unlimited. It provides 10000 responses over 200 pages for the user, with the last page rendering in about 100ms.

If the user requires all responses, they can still export them all as a CSV. Currently only 28 paths have more than 10000 responses, all of which are Done pages which need to be refactored at some point to display only those with comments.

This should be coupled with frontend changes, providing copy informing the user to download a CSV if there's more than 10000 responses.

/cc @tijmenb @benilovj 