### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'pg', '0.18.2'
 gem 'logstasher', '0.6.2'
 gem 'airbrake', '4.1.0'
 gem 'sidekiq', '3.3.4'
+gem 'sidekiq-statsd', '0.1.5'
 gem 'unicorn', '4.9.0'
 gem 'gds-api-adapters', '20.1.1'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,10 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -202,6 +206,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    statsd-ruby (1.2.1)
     thor (0.19.1)
     thread_safe (0.3.5)
     timecop (0.7.3)
@@ -252,6 +257,7 @@ DEPENDENCIES
   rspec-rails (= 3.2.1)
   shoulda-matchers (= 2.8.0)
   sidekiq (= 3.3.4)
+  sidekiq-statsd (= 0.1.5)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   spring (= 1.3.5)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,6 +14,9 @@ redis_config = {
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.support-api', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq