### PR TITLE
Use content_ids to reconcile orgs between the saved DB and the Content Store/API

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,9 @@ class Organisation < ActiveRecord::Base
 
   def self.for_path(path)
     orgs_data = SupportApi.organisation_lookup.organisations_for(path) || []
-    orgs_data.map {|org_info| Organisation.where(org_info).first_or_create! }
+    orgs_data.map { |org_info|
+      Organisation.create_with(org_info).find_or_create_by(content_id: org_info[:content_id])
+    }
   end
 
   def as_json(options)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,6 +6,7 @@ class Organisation < ActiveRecord::Base
   validates :slug, presence: true
   validates :web_url, presence: true
   validates :title, presence: true
+  validates :content_id, presence: true
 
   def self.for_path(path)
     orgs_data = SupportApi.organisation_lookup.organisations_for(path) || []

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,10 +9,7 @@ class Organisation < ActiveRecord::Base
   validates :content_id, presence: true
 
   def self.for_path(path)
-    orgs_data = SupportApi.organisation_lookup.organisations_for(path) || []
-    orgs_data.map { |org_info|
-      Organisation.create_with(org_info).find_or_create_by(content_id: org_info[:content_id])
-    }
+    SupportApi.organisation_lookup.organisations_for(path)
   end
 
   def as_json(options)

--- a/db/migrate/20151202212408_clean_up_org_without_content_id.rb
+++ b/db/migrate/20151202212408_clean_up_org_without_content_id.rb
@@ -1,0 +1,22 @@
+class CleanUpOrgWithoutContentId < ActiveRecord::Migration
+  def change
+    orgs_without_a_content_id = Organisation.where(content_id: nil).count
+    raise "Unexpected number (#{orgs_without_a_content_id}) of organisations without a content_id" if orgs_without_a_content_id > 1
+
+    old_org = Organisation.find_by(slug: 'schools-commissioner')
+    new_org = Organisation.find_by(slug: "schools-commissioners-group")
+    if old_org && new_org
+      old_org.content_items.each do |item|
+        item.organisations.delete(old_org)
+        item.organisations << new_org
+      end
+
+      old_org.reload
+      raise "Old org shouldn't have any content items but has #{old_org.content_items.count}" unless old_org.content_items.count == 0
+      old_org.delete
+    end
+
+    orgs_without_a_content_id = Organisation.where(content_id: nil).count
+    raise "There should be 0 organisations without a content_id but there are #{orgs_without_a_content_id}" if orgs_without_a_content_id > 0
+  end
+end

--- a/db/migrate/20151203001139_make_organisation_content_ids_not_null.rb
+++ b/db/migrate/20151203001139_make_organisation_content_ids_not_null.rb
@@ -1,0 +1,5 @@
+class MakeOrganisationContentIdsNotNull < ActiveRecord::Migration
+  def change
+    change_column :organisations, :content_id, :string, limit: 255, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -164,7 +164,7 @@ CREATE TABLE organisations (
     updated_at timestamp without time zone NOT NULL,
     acronym character varying(255),
     govuk_status character varying(255),
-    content_id character varying(255)
+    content_id character varying(255) NOT NULL
 );
 
 
@@ -356,4 +356,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150623151655');
 INSERT INTO schema_migrations (version) VALUES ('20150915134640');
 
 INSERT INTO schema_migrations (version) VALUES ('20151202212408');
+
+INSERT INTO schema_migrations (version) VALUES ('20151203001139');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -355,3 +355,5 @@ INSERT INTO schema_migrations (version) VALUES ('20150623151655');
 
 INSERT INTO schema_migrations (version) VALUES ('20150915134640');
 
+INSERT INTO schema_migrations (version) VALUES ('20151202212408');
+

--- a/lib/organisation_lookups/catchall_assign_to_gds.rb
+++ b/lib/organisation_lookups/catchall_assign_to_gds.rb
@@ -8,6 +8,7 @@ module OrganisationLookups
 
     def organisations_for(path)
       [{
+        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
         slug: "government-digital-service",
         web_url: "https://www.gov.uk/government/organisations/government-digital-service",
         title: "Government Digital Service",

--- a/lib/organisation_lookups/catchall_assign_to_gds.rb
+++ b/lib/organisation_lookups/catchall_assign_to_gds.rb
@@ -7,12 +7,7 @@ module OrganisationLookups
     end
 
     def organisations_for(path)
-      [{
-        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
-        slug: "government-digital-service",
-        web_url: "https://www.gov.uk/government/organisations/government-digital-service",
-        title: "Government Digital Service",
-      }]
+      [Organisation.find_by!(slug: "government-digital-service")]
     end
 
     def path_of_parent_content_item(path)

--- a/lib/organisation_lookups/content_api_with_organisations.rb
+++ b/lib/organisation_lookups/content_api_with_organisations.rb
@@ -18,12 +18,13 @@ module OrganisationLookups
     def orgs_from_tags(tags)
       org_tags = tags.select {|t| t["details"]["type"] == "organisation" }
       org_tags.map { |tag|
-        {
+        org_info = {
           content_id: tag["content_id"],
           slug: tag["slug"],
           web_url: tag["web_url"],
           title: tag["title"],
         }
+        Organisation.create_with(org_info).find_or_create_by(content_id: org_info[:content_id])
       }
     end
 

--- a/lib/organisation_lookups/content_store_with_organisations.rb
+++ b/lib/organisation_lookups/content_store_with_organisations.rb
@@ -7,12 +7,13 @@ module OrganisationLookups
     def organisations_for(path)
       response = @content_store.content_item(path)
       if response && organisation?(response)
-        [{
+        org_info = {
           content_id: response["content_id"],
           slug: response["base_path"].split("/").last,
           web_url: Plek.new.website_root + response["base_path"],
           title: response["title"],
-        }]
+        }
+        [Organisation.create_with(org_info).find_or_create_by(content_id: org_info[:content_id])]
       else
         []
       end

--- a/lib/organisation_lookups/govuk_team_owned_pages.rb
+++ b/lib/organisation_lookups/govuk_team_owned_pages.rb
@@ -8,6 +8,7 @@ module OrganisationLookups
 
     def organisations_for(path)
       [{
+        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
         slug: "government-digital-service",
         web_url: "https://www.gov.uk/government/organisations/government-digital-service",
         title: "Government Digital Service",

--- a/lib/organisation_lookups/govuk_team_owned_pages.rb
+++ b/lib/organisation_lookups/govuk_team_owned_pages.rb
@@ -7,12 +7,7 @@ module OrganisationLookups
     end
 
     def organisations_for(path)
-      [{
-        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
-        slug: "government-digital-service",
-        web_url: "https://www.gov.uk/government/organisations/government-digital-service",
-        title: "Government Digital Service",
-      }]
+      [Organisation.find_by!(slug: "government-digital-service")]
     end
 
     def path_of_parent_content_item(path)

--- a/lib/organisation_lookups/worldwide_organisation_pages.rb
+++ b/lib/organisation_lookups/worldwide_organisation_pages.rb
@@ -5,29 +5,12 @@ module OrganisationLookups
     end
 
     def organisations_for(path)
-      case path
-      when /dfid/ then
-        [{
-          content_id: "db994552-7644-404d-a770-a2fe659c661f",
-          slug: "department-for-international-development",
-          web_url: "https://www.gov.uk/government/organisations/department-for-international-development",
-          title: "Department for International Development",
-        }]
-      when /uk-trade-investment/ then
-        [{
-          content_id: "b045c8df-d3c4-4219-88d8-264dc9ee5cc8",
-          slug: "uk-trade-investment",
-          web_url: "https://www.gov.uk/government/organisations/uk-trade-investment",
-          title: "UK Trade & Investment",
-        }]
-      else
-        [{
-          content_id: "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
-          slug: "foreign-commonwealth-office",
-          web_url: "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
-          title: "Foreign & Commonwealth Office",
-        }]
-      end
+      org_slug = case path
+                 when /dfid/ then "department-for-international-development"
+                 when /uk-trade-investment/ then "uk-trade-investment"
+                 else "foreign-commonwealth-office"
+                 end
+      [Organisation.find_by!(slug: org_slug)]
     end
 
     def path_of_parent_content_item(path)

--- a/lib/organisation_lookups/worldwide_organisation_pages.rb
+++ b/lib/organisation_lookups/worldwide_organisation_pages.rb
@@ -8,18 +8,21 @@ module OrganisationLookups
       case path
       when /dfid/ then
         [{
+          content_id: "db994552-7644-404d-a770-a2fe659c661f",
           slug: "department-for-international-development",
           web_url: "https://www.gov.uk/government/organisations/department-for-international-development",
           title: "Department for International Development",
         }]
       when /uk-trade-investment/ then
         [{
+          content_id: "b045c8df-d3c4-4219-88d8-264dc9ee5cc8",
           slug: "uk-trade-investment",
           web_url: "https://www.gov.uk/government/organisations/uk-trade-investment",
           title: "UK Trade & Investment",
         }]
       else
         [{
+          content_id: "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
           slug: "foreign-commonwealth-office",
           web_url: "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
           title: "Foreign & Commonwealth Office",

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -23,6 +23,34 @@ FactoryGirl.define do
     acronym { title.split.map { |s| s[0] }.join.upcase }
     govuk_status "live"
     sequence(:content_id) { |n| "content_id_#{n}" }
+
+    factory :gds do
+      content_id "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+      slug "government-digital-service"
+      web_url "https://www.gov.uk/government/organisations/government-digital-service"
+      title "Government Digital Service"
+    end
+
+    factory :dfid do
+      content_id "db994552-7644-404d-a770-a2fe659c661f"
+      slug "department-for-international-development"
+      web_url "https://www.gov.uk/government/organisations/department-for-international-development"
+      title "Department for International Development"
+    end
+
+    factory :ukti do
+      content_id "b045c8df-d3c4-4219-88d8-264dc9ee5cc8"
+      slug "uk-trade-investment"
+      web_url "https://www.gov.uk/government/organisations/uk-trade-investment"
+      title "UK Trade & Investment"
+    end
+
+    factory :fco do
+      content_id "9adfc4ed-9f6c-4976-a6d8-18d34356367c"
+      slug "foreign-commonwealth-office"
+      web_url "https://www.gov.uk/government/organisations/foreign-commonwealth-office"
+      title "Foreign & Commonwealth Office"
+    end
   end
 
   factory :content_item do

--- a/spec/models/organisation_lookup_spec.rb
+++ b/spec/models/organisation_lookup_spec.rb
@@ -9,6 +9,8 @@ describe OrganisationLookup do
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::ContentStore
 
+  let!(:gds) { create(:gds) }
+
   let(:content_api) { GdsApi::ContentApi.new(Plek.find('contentapi')) }
   let(:content_store) { GdsApi::ContentStore.new(Plek.find('content-store')) }
   subject(:api) { OrganisationLookup.new(content_api, content_store) }
@@ -59,24 +61,17 @@ describe OrganisationLookup do
       }
     }
 
-    let(:gds_org_info) {
-      {
-        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
-        slug: "government-digital-service",
-        web_url: "https://www.gov.uk/government/organisations/government-digital-service",
-        title: "Government Digital Service",
-      }
-    }
-
     context "(mainstream content)" do
       it "fetches the organisations" do
         content_api_has_an_artefact("contact-ukvi", default_content_api_response)
 
         expect(api.organisations_for("/contact-ukvi/overview")).to eq([
-          content_id: "04148522-b0c1-4137-b687-5f3c3bdd561a",
-          slug: "uk-visas-and-immigration",
-          web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
-          title: "UK Visas and Immigration",
+          Organisation.find_by!(
+            content_id: "04148522-b0c1-4137-b687-5f3c3bdd561a",
+            slug: "uk-visas-and-immigration",
+            web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
+            title: "UK Visas and Immigration",
+          )
         ])
       end
     end
@@ -89,10 +84,12 @@ describe OrganisationLookup do
         )
 
         expect(api.organisations_for("/government/publications/customer-service-commitments-uk-visas-and-immigration")).to eq([
-          content_id: "04148522-b0c1-4137-b687-5f3c3bdd561a",
-          slug: "uk-visas-and-immigration",
-          web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
-          title: "UK Visas and Immigration",
+          Organisation.find_by!(
+            content_id: "04148522-b0c1-4137-b687-5f3c3bdd561a",
+            slug: "uk-visas-and-immigration",
+            web_url: "https://www.gov.uk/government/organisations/uk-visas-and-immigration",
+            title: "UK Visas and Immigration",
+          )
         ])
       end
     end
@@ -100,7 +97,7 @@ describe OrganisationLookup do
     context "(GDS-owned pages)" do
       it "should have GDS as the owning org" do
         [ "/", "/help", "/help/beta", "/contact", "/contact/govuk", "/search", "/browse", "/browse/driving" ].each do |gds_owned_path|
-          expect(api.organisations_for(gds_owned_path)).to eq([gds_org_info])
+          expect(api.organisations_for(gds_owned_path)).to eq([gds])
         end
       end
     end
@@ -132,7 +129,7 @@ describe OrganisationLookup do
           "/government/organisations/hm-revenue-customs/contact/corporation-tax-enquiries",
           "/government/organisations/hm-revenue-customs/services-information",
         ].each do |hmrc_path|
-          expect(api.organisations_for(hmrc_path)).to eq([hmrc_info])
+          expect(api.organisations_for(hmrc_path)).to eq([Organisation.find_by!(hmrc_info)])
         end
       end
     end
@@ -145,7 +142,7 @@ describe OrganisationLookup do
 
       it "should be attributed to GDS" do
         ["/non-existent-page", "/page-not-found"].each do |gds_owned_path|
-          expect(api.organisations_for(gds_owned_path)).to eq([gds_org_info])
+          expect(api.organisations_for(gds_owned_path)).to eq([gds])
         end
       end
     end

--- a/spec/models/organisation_lookup_spec.rb
+++ b/spec/models/organisation_lookup_spec.rb
@@ -61,6 +61,7 @@ describe OrganisationLookup do
 
     let(:gds_org_info) {
       {
+        content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
         slug: "government-digital-service",
         web_url: "https://www.gov.uk/government/organisations/government-digital-service",
         title: "Government Digital Service",

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -10,6 +10,7 @@ describe ContentItemEnrichmentWorker do
     let(:problem_report) { create(:problem_report, path: "/unknown-org-page") }
 
     before do
+      create(:gds)
       content_api_does_not_have_an_artefact("unknown-org-page")
       subject.perform(problem_report.id)
       problem_report.reload

--- a/spec/models/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/models/workers/content_item_enrichment_worker_spec.rb
@@ -27,6 +27,7 @@ describe ContentItemEnrichmentWorker do
       api_response = artefact_for_slug("vat-rates").tap do |hash|
         hash["tags"] = [
           {
+            content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
             slug: "hm-revenue-customs",
             web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
             title: "HM Revenue & Customs",
@@ -59,6 +60,7 @@ describe ContentItemEnrichmentWorker do
       api_response = artefact_for_slug("vat-rates").tap do |hash|
         hash["tags"] = [
           {
+            content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
             slug: "hm-revenue-customs",
             web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
             title: "HM Revenue & Customs",
@@ -73,6 +75,7 @@ describe ContentItemEnrichmentWorker do
       api_response = artefact_for_slug("vat-rates").tap do |hash|
         hash["tags"] = [
           {
+            content_id: "38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
             slug: "air-accidents-investigation-branch",
             web_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
             title: "aaib",

--- a/spec/requests/problem_reports_spec.rb
+++ b/spec/requests/problem_reports_spec.rb
@@ -16,6 +16,7 @@ describe "Problem reports" do
     api_response = artefact_for_slug("vat-rates").tap do |hash|
       hash["tags"] = [
         {
+          content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
           slug: "hm-revenue-customs",
           web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
           title: "HM Revenue & Customs",

--- a/spec/requests/problem_reports_spec.rb
+++ b/spec/requests/problem_reports_spec.rb
@@ -104,9 +104,7 @@ javascript_enabled: true
 
   context "fetching" do
     let!(:gds) {
-      create(:organisation,
-        slug: "government-digital-service"
-      )
+      create(:gds)
     }
     let!(:problem_report) {
       create(:problem_report,


### PR DESCRIPTION
This PR:
- makes `content_id` mandatory for all orgs
- cleans up the org without a `content_id`
- uses `content_id`s when dynamically creating orgs that aren't imported yet in the nightly import. This allows the reconciliation which happens during import to work correctly.

Open TODOs:

- [x] this relies on #76 and should be rebased after that's merged

~~f64eff7 should probably move the code out of the migration into a more generic data hygiene class that's unit tested~~

/cc @jamiecobbett 