### PR TITLE
Suppress error message when pushing to Performance Platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'airbrake', '4.1.0'
 gem 'sidekiq', '3.3.4'
 gem 'sidekiq-statsd', '0.1.5'
 gem 'unicorn', '4.9.0'
-gem 'gds-api-adapters', '20.1.1'
+gem 'gds-api-adapters', '26.4.0'
 gem 'whenever', '0.9.4', require: false
 gem 'mlanett-redis-lock', '0.2.6'
 gem "gds_zendesk", '2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.5.0)
@@ -67,7 +67,7 @@ GEM
     fakefs (0.6.7)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (26.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -108,14 +108,14 @@ GEM
       redis
     multi_json (1.11.0)
     multipart-post (2.0.0)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     pg (0.18.2)
     plek (1.10.0)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -244,7 +244,7 @@ DEPENDENCIES
   ci_reporter_rspec (= 1.0.0)
   factory_girl_rails (= 4.5.0)
   fakefs
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 26.4.0)
   gds_zendesk (= 2.0.0)
   kaminari (~> 0.16.3)
   logstasher (= 0.6.2)
@@ -266,3 +266,6 @@ DEPENDENCIES
   user_agent_parser
   webmock (= 1.21.0)
   whenever (= 0.9.4)
+
+BUNDLED WITH
+   1.10.4

--- a/app/workers/service_feedback_pp_uploader_worker.rb
+++ b/app/workers/service_feedback_pp_uploader_worker.rb
@@ -13,6 +13,8 @@ class ServiceFeedbackPPUploaderWorker
     )
     request_details = ServiceFeedbackAggregatedMetrics.new(Time.utc(year, month, day), transaction_slug).to_h
     api.submit_service_feedback_day_aggregate(transaction_slug, request_details)
+  rescue GdsApi::PerformancePlatformDatasetNotConfigured => e
+    Rails.logger.warn(e.message)
   end
 
   def self.run

--- a/spec/models/workers/service_feedback_pp_uploader_worker_spec.rb
+++ b/spec/models/workers/service_feedback_pp_uploader_worker_spec.rb
@@ -5,9 +5,11 @@ require 'gds_api/test_helpers/performance_platform/data_in'
 describe ServiceFeedbackPPUploaderWorker do
   include GdsApi::TestHelpers::PerformancePlatform::DataIn
 
-  it "pushes yesterday's stats for each slug to the performance platform" do
+  before do
     Timecop.travel Date.new(2013,2,11)
+  end
 
+  it "pushes yesterday's stats for each slug to the performance platform" do
     create(:service_feedback, slug: "waste_carrier_or_broker_registration", created_at: Date.yesterday)
     create(:service_feedback, slug: "apply_carers_allowance", created_at: Date.yesterday)
 
@@ -18,5 +20,22 @@ describe ServiceFeedbackPPUploaderWorker do
 
     expect(stub_post1).to have_been_made
     expect(stub_post2).to have_been_made
+  end
+
+  it "ignores errors arising from a dataset not existing in the Performance Platform" do
+    # as of Dec 2015, creating service feedback datasets for each new transaction
+    # in the Performance Platform is a manual process done by the PP team.
+    # It's often the case that feedback starts coming into the Support API for
+    # transactions that don't yet have a dataset for collecting this data.
+
+    # Until the dataset is created, the Support API should silently consume the
+    # failure. The data is still retained in the Support API DB, in case it needs
+    # to be backfilled to the PP.
+    create(:service_feedback, slug: "waste_carrier_or_broker_registration", created_at: Date.yesterday)
+    request = stub_pp_dataset_unavailable
+
+    expect { ServiceFeedbackPPUploaderWorker.run }.to_not raise_error
+
+    expect(request).to have_been_made
   end
 end


### PR DESCRIPTION
As of Dec 2015, creating service feedback datasets for each new transaction
in the Performance Platform is a manual process done by the PP team.

It's often the case that feedback starts coming into the Support API for
transactions that don't yet have a dataset for collecting this data.

Until the dataset is created, the Support API should silently consume the
failure. The data is still retained in the Support API DB, in case it needs
to be backfilled to the PP.

I've discussed this with @bmwelby.

Before merging:

- [x] merge https://github.com/alphagov/gds-api-adapters/pull/405
- [x] bump and update `gds-api-adapters` gem
