### PR TITLE
Remove unused '/anonymous-feedback/organisations' endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,6 @@ Rails.application.routes.draw do
     get '/organisations/:slug', to: "organisations#show"
   end
 
-  # TODO: Remove this endpoint once the support app has been repointed to /organisations
-  get '/anonymous-feedback/organisations', to: "organisations#index"
   resources :organisations,
             only: [:index, :show],
             format: false,

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -42,7 +42,7 @@ describe "Organisations that have feedback left on 'their' content" do
   end
 
   it "can be retrieved (so that it's possible to not deal with orgs that have no feedback)" do
-    get_json "/anonymous-feedback/organisations"
+    get_json "/organisations"
 
     expect(json_response).to contain_exactly(hmrc_info, ukvi_info)
   end


### PR DESCRIPTION
This has been replaced by the '/organisations' endpoint and the only
consumer of this endpoint (the Support app) has been moved to the new
endpoint.

(this tech task was languishing on a long-forgotten TODO list of mine for a year).