### PR TITLE
Add aggregated feedback details to CSV exports

### DIFF
--- a/app/presenters/feedback_csv_row_presenter.rb
+++ b/app/presenters/feedback_csv_row_presenter.rb
@@ -19,7 +19,7 @@ class FeedbackCsvRowPresenter
       row.created_at.strftime("%F %T"),
       row.type == "service-feedback" ? row.slug : row.path,
       details_text,
-      row.type == "service-feedback" ? row.service_satisfaction_rating.to_s : "",
+      service_satisfaction_rating,
       parsed_user_agent.family,
       parsed_user_agent.version.to_s,
       parsed_user_agent.os.family,
@@ -41,6 +41,16 @@ class FeedbackCsvRowPresenter
       row.details
     when "long-form-contact"
       row.details
+    when "aggregated-service-feedback"
+      "Rating of #{row.service_satisfaction_rating}: #{row.details}"
+    end
+  end
+
+  def service_satisfaction_rating
+    if row.type =~ /^(aggregated-)?service-feedback$/
+      row.service_satisfaction_rating.to_s
+    else
+      ""
     end
   end
 end

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -13,6 +13,11 @@ FactoryGirl.define do
       service_satisfaction_rating 5
     end
 
+    factory :aggregated_service_feedback, class: AggregatedServiceFeedback do
+      path { "/done/#{slug}" }
+      slug "apply-carers-allowance"
+    end
+
     factory :long_form_contact, class: LongFormContact
   end
 

--- a/spec/models/service_feedback_aggregator_spec.rb
+++ b/spec/models/service_feedback_aggregator_spec.rb
@@ -45,12 +45,12 @@ describe ServiceFeedbackAggregator do
         let(:rating) { 2 }
 
         it "creates two aggregated service feedbacks with a rating of 1 and 2" do
-          expect(AggregatedServiceFeedback.pluck(:service_satisfaction_rating)).to eq([2,1])
+          expect(AggregatedServiceFeedback.pluck(:service_satisfaction_rating)).to include(1, 2)
         end
       end
 
       context "with different dates" do
-        let(:date) { Time.new(2013,2,10,11) }
+        let(:date) { Time.new(2013,2,11) }
 
         it "creates only one aggregated service feedback" do
           expect(AggregatedServiceFeedback.all.count).to eq 1

--- a/spec/presenters/feedback_csv_row_presenter_spec.rb
+++ b/spec/presenters/feedback_csv_row_presenter_spec.rb
@@ -4,6 +4,7 @@ describe FeedbackCsvRowPresenter do
   subject(:instance) { described_class.new(row) }
   let(:problem_report) { build(:problem_report, created_at: Time.utc(2015,4), what_doing: "Finding the thing", what_wrong: "Couldn't find the thing\nThanks") }
   let(:service_feedback) { build(:service_feedback, created_at: Time.utc(2015,4), details: "It was good\nWell done", service_satisfaction_rating: 3) }
+  let(:aggregated_service_feedback) { build(:aggregated_service_feedback, created_at: Time.utc(2015,4), details: 1, service_satisfaction_rating: 3) }
   let(:long_form_contact) { build(:long_form_contact, created_at: Time.utc(2015,4), details: "It was really good\nReally.\nGood job") }
 
   describe "#to_a" do
@@ -43,6 +44,24 @@ describe FeedbackCsvRowPresenter do
           row.user_agent,
           "http://www.example.com/foo",
           "service-feedback"
+        ]
+      end
+    end
+
+    context "for aggregated service feedback" do
+      let(:row) { aggregated_service_feedback }
+      it "presents the correct columns" do
+        expect(subject).to eq [
+          "2015-04-01 00:00:00",
+          row.path,
+          "Rating of #{row.service_satisfaction_rating}: #{row.details}",
+          "3",
+          "IE",
+          "9.0",
+          "Windows Vista",
+          row.user_agent,
+          "http://www.example.com/foo",
+          "aggregated-service-feedback"
         ]
       end
     end


### PR DESCRIPTION
CSV exports showed an empty cell for aggregated feedback lines, instead of the "Rating of 1: 12" type details field that is displayed in the view. This fixes it and ensures CSV exports include this details field.

This also improves two existing tests:
1. When testing different ratings, we shouldn't expect results in a specific order. This
test was failing intermittently.
2. The test for different dates only had different times, not a different day. This
fixes it.

This work was carried out pairing with @mgrassotti, and tested on integration by deploying this branch, and then exporting a CSV for a /done/ page as well as a regular page.

[Trello](https://trello.com/c/TVlBgbol/425-feedex-aggregation-not-adding-up-correctly)