### PR TITLE
Allow export of Global statistics

### DIFF
--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -30,8 +30,8 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
       clean_params = params.require(:export_request).permit(*permitted_params)
       {
         filters: {
-          from: parse_date(clean_params[:from]),
-          to: parse_date(clean_params[:to]),
+          from: parse_date(clean_params[:from_date]),
+          to: parse_date(clean_params[:to_date]),
           path_prefix: clean_params[:path_prefix],
           organisation_slug: clean_params[:organisation]
         },

--- a/app/controllers/anonymous_feedback/global_export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/global_export_requests_controller.rb
@@ -1,0 +1,27 @@
+class AnonymousFeedback::GlobalExportRequestsController < ApplicationController
+  def create
+    export_request = GlobalExportRequest.new(global_export_request_params)
+    if export_request.valid?
+      GenerateGlobalExportCsvWorker.perform_async(global_export_request_params)
+      render nothing: true, status: 202
+    else
+      render json: { "errors" => export_request.errors.to_a }, status: 422
+    end
+  end
+
+private
+  def global_export_request_params
+    permitted_params = [
+      :from_date,
+      :to_date,
+      :notification_email
+    ]
+
+    clean_params = params.require(:global_export_request).permit(*permitted_params)
+    {
+      from_date: parse_date(clean_params[:from_date]),
+      to_date: parse_date(clean_params[:to_date]),
+      notification_email: clean_params[:notification_email],
+    }
+  end
+end

--- a/app/mailers/global_export_notification.rb
+++ b/app/mailers/global_export_notification.rb
@@ -1,0 +1,13 @@
+class GlobalExportNotification < ActionMailer::Base
+  default from: "inside-government@digital.cabinet-office.gov.uk"
+  layout false
+
+  def notification_email(notification_email, filename, csv_contents)
+    attachments[filename] = csv_contents
+
+    mail(
+      to: notification_email,
+      subject: "[GOV.UK Feedback Explorer] Your global export is attached"
+    )
+  end
+end

--- a/app/models/global_export_csv_generator.rb
+++ b/app/models/global_export_csv_generator.rb
@@ -1,0 +1,33 @@
+class GlobalExportCsvGenerator
+  def initialize(from_date, to_date)
+    @from_date = from_date
+    @to_date = to_date
+  end
+
+  def call
+    return filename, generate_csv
+  end
+
+private
+  attr_reader :from_date, :to_date
+
+  def results
+    ProblemReport.
+      created_between_days(from_date, to_date).
+      select("date(created_at) as created_at_date, COUNT(id) as report_count").
+      group("created_at_date").
+      order("created_at_date").
+      limit(10_000)
+  end
+
+  def generate_csv
+    CSV.generate do |csv|
+      csv << ['date', 'report_count']
+      results.each { |r| csv << [r[:created_at_date].strftime('%Y-%m-%d'), r[:report_count]] }
+    end
+  end
+
+  def filename
+    "feedex_#{from_date.iso8601}_#{to_date.iso8601}.csv"
+  end
+end

--- a/app/models/global_export_request.rb
+++ b/app/models/global_export_request.rb
@@ -1,0 +1,9 @@
+class GlobalExportRequest
+  include ActiveModel::Model
+
+  attr_accessor :notification_email, :from_date, :to_date
+
+  validates :notification_email, presence: true
+  validates :from_date, presence: true
+  validates :to_date, presence: true
+end

--- a/app/views/global_export_notification/notification_email.text.erb
+++ b/app/views/global_export_notification/notification_email.text.erb
@@ -1,0 +1,5 @@
+Hi,
+
+Your CSV file is attached.
+
+- Feedex

--- a/app/workers/generate_global_export_csv_worker.rb
+++ b/app/workers/generate_global_export_csv_worker.rb
@@ -1,0 +1,12 @@
+class GenerateGlobalExportCsvWorker
+  include Sidekiq::Worker
+
+  def perform(export_params)
+    filename, contents = GlobalExportCsvGenerator.new(
+      Date.strptime(export_params["from_date"], "%Y-%m-%d").beginning_of_day,
+      Date.strptime(export_params["to_date"], "%Y-%m-%d").end_of_day,
+    ).call
+
+    GlobalExportNotification.notification_email(export_params["notification_email"], filename, contents).deliver_now
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,12 @@ Rails.application.routes.draw do
               controller: "export_requests",
               as: "export_request"
 
+    resources "global-export-requests",
+              only: [:create],
+              format: false,
+              controller: "global_export_requests",
+              as: "global_export_request"
+
     get '/problem-reports/:date/totals',
         constraints: { date: /\d{4}-\d{2}-\d{2}/ },
         to: 'problem_reports#totals'

--- a/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe AnonymousFeedback::GlobalExportRequestsController, type: :controller do
+  describe "#create" do
+    context "with valid parameters" do
+      it "succeeds" do
+        expect(GenerateGlobalExportCsvWorker).to receive(:perform_async).once
+
+        response = post :create, global_export_request: {
+          from_date: "2015-05-01",
+          to_date: "2015-06-01",
+          notification_email: "foo@example.com",
+        }
+
+        expect(response).to be_accepted
+      end
+    end
+
+    context "with invalid parameters" do
+      it "fails" do
+        expect(GenerateGlobalExportCsvWorker).not_to receive(:perform_async)
+
+        response = post :create, global_export_request: {
+          from_date: "2015-05-01",
+          to_date: "2015-06-01",
+        }
+
+        expect(response).to be_unprocessable
+      end
+    end
+  end
+end

--- a/spec/models/global_export_csv_generator_spec.rb
+++ b/spec/models/global_export_csv_generator_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe GlobalExportCsvGenerator do
+  let(:from_date) { Date.new(2015, 6, 1) }
+  let(:to_date) { Date.new(2015, 6, 5) }
+
+  before do
+    (from_date..to_date).each { |d| create(:problem_report, created_at: d) }
+    2.times.map { create(:problem_report, created_at: from_date + 1.day) }
+    2.times { create(:problem_report, created_at: from_date - 1.day) }
+  end
+
+  let(:result) { described_class.new(from_date, to_date).call.last }
+  let(:filename) { described_class.new(from_date, to_date).call.first }
+
+  describe "#call" do
+    it "returns the correct reports" do
+      expect(result.split("\n")).to eq([
+        'date,report_count',
+        '2015-06-01,1',
+        '2015-06-02,3',
+        '2015-06-03,1',
+        '2015-06-04,1',
+        '2015-06-05,1',
+      ])
+    end
+
+    it "has 5 records and a header" do
+      expect(result.split("\n").count).to eq(6)
+    end
+
+    it "is parseable as csv" do
+      expect(CSV.parse(result).count).to eq(6)
+    end
+
+    it "returns a sane filename" do
+      expect(filename).to eq("feedex_#{from_date.iso8601}_#{to_date.iso8601}.csv")
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/ptXseJEJ/13-export-global-anonymous-feedback-csv)

This generates and emails (as an attachment) a CSV file containing two
fields; `date` and `report_count`, for all anonymous feedback submitted
to GOV.UK.

The aim here is to provide a mechanism to export this data so that
statistical analysis can be performed. At the moment this analysis
happens on data from zendesk; we'd like to avoid sending all types of
anonymous feedback to zendesk, so we need to have another way to provide
the data.