### PR TITLE
Group organisation report summaries by path

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -23,7 +23,7 @@ class ContentItem < ActiveRecord::Base
       select("#{last_30_days} AS last_30_days").
       select("#{last_90_days} AS last_90_days").
       where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days).
-      group("content_items.id").
+      group("content_items.path").
       having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0").
       order("#{ordering} #{ordering_mode}")
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -47,4 +47,23 @@ describe ContentItem do
       { path: "/def", last_7_days: 0, last_30_days: 0, last_90_days: 4 }
     ])
   end
+
+  it "aggregates content items with similar paths" do
+    create(:content_item, organisations: orgs, path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+      ]
+    )
+    create(:content_item, organisations: orgs, path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+      ]
+    )
+
+    expect(ContentItem.summary).to eq([
+      { path: "/abc", last_7_days: 0, last_30_days: 4, last_90_days: 4 },
+    ])
+  end
 end


### PR DESCRIPTION
# [Trello card](https://trello.com/c/7kwsLiHh/22-duplicates-in-feedex)

## Before
<img width="1159" alt="screenshot 2016-08-09 16 33 13" src="https://cloud.githubusercontent.com/assets/615627/17522492/2885e05e-5e4f-11e6-9e61-33c14620a787.png">

## After
<img width="1157" alt="screenshot 2016-08-09 16 33 25" src="https://cloud.githubusercontent.com/assets/615627/17522500/2cffdb1c-5e4f-11e6-8090-ea502961ce4f.png">


## WTF?

In the database for the `support-api`, it's possible for there to be multiple `ContentItem`'s for a given `path`. Case in point:

    irb(main):005:0> ContentItem.where(path: '/calculate-your-holiday-entitlement').count
    => 255

When a problem report is raised, a representation of the content item relating to that problem report is persisted to the database.

The process of accessing this content item is pretty convoluted, and reading the code it would *appear* to be trying to update the existing content item in the database if one already exists, but it appears that this isn't happening.

Unpicking this code requires a significant refactor and some reasonable understanding of the GOV.UK content API/content stores/publishing API, which I don't have yet, but in the meantime let's fix the user facing bug.

I imagine we'll revisit this as part of revisiting the data model of problem reports.