### PR TITLE
Correctly parse dates for export requests

### DIFF
--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -30,8 +30,8 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
       clean_params = params.require(:export_request).permit(*permitted_params)
       {
         filters: {
-          from: parse_date(clean_params[:from_date]),
-          to: parse_date(clean_params[:to_date]),
+          from: parse_date(clean_params[:from]),
+          to: parse_date(clean_params[:to]),
           path_prefix: clean_params[:path_prefix],
           organisation_slug: clean_params[:organisation]
         },

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
       subject { response }
 
       it { is_expected.to be_accepted }
+
+      it "creates a feedback export request with the correct filters" do
+        expect(FeedbackExportRequest.count).to eq(1)
+        feedback_export_request = FeedbackExportRequest.last
+
+        expect(feedback_export_request.filters).to eq({
+          from: Date.new(2015, 05, 01),
+          to: Date.new(2015, 06, 01),
+          organisation_slug: nil,
+          path_prefix: "/",
+        })
+      end
     end
 
     context "posted with invalid parameters" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/lkPUHwQD/31-csv-export-on-feedback-includes-all-feedback-rather-than-just-the-dates-requested)

When performing an export request, we should use 'from' and 'to', not 'from_date' and 'to_date', as these are not present in the incoming hash.

This means that export requests have *never* respected dates.