### PR TITLE
Send page improvements to Zendesk

### DIFF
--- a/app/controllers/page_improvements_controller.rb
+++ b/app/controllers/page_improvements_controller.rb
@@ -13,6 +13,6 @@ class PageImprovementsController < ApplicationController
 
 private
   def page_improvement_attributes
-    params.slice(:description, :path, :name, :email, :user_agent)
+    params.slice(:description, :url, :name, :email, :user_agent)
   end
 end

--- a/app/controllers/page_improvements_controller.rb
+++ b/app/controllers/page_improvements_controller.rb
@@ -1,0 +1,18 @@
+class PageImprovementsController < ApplicationController
+  def create
+    page_improvement = PageImprovement.new(page_improvement_attributes)
+
+    if page_improvement.valid?
+      GDS_ZENDESK_CLIENT.ticket.create!(page_improvement.zendesk_ticket_attributes)
+
+      render json: { status: 'success' }
+    else
+      render json: { status: 'error', errors: page_improvement.errors }, status: 422
+    end
+  end
+
+private
+  def page_improvement_attributes
+    params.slice(:description, :path, :name, :email)
+  end
+end

--- a/app/controllers/page_improvements_controller.rb
+++ b/app/controllers/page_improvements_controller.rb
@@ -5,7 +5,7 @@ class PageImprovementsController < ApplicationController
     if page_improvement.valid?
       GDS_ZENDESK_CLIENT.ticket.create!(page_improvement.zendesk_ticket_attributes)
 
-      render json: { status: 'success' }
+      render json: { status: 'success' }, status: 201
     else
       render json: { status: 'error', errors: page_improvement.errors }, status: 422
     end

--- a/app/controllers/page_improvements_controller.rb
+++ b/app/controllers/page_improvements_controller.rb
@@ -13,6 +13,6 @@ class PageImprovementsController < ApplicationController
 
 private
   def page_improvement_attributes
-    params.slice(:description, :path, :name, :email)
+    params.slice(:description, :path, :name, :email, :user_agent)
   end
 end

--- a/app/models/page_improvement.rb
+++ b/app/models/page_improvement.rb
@@ -15,11 +15,30 @@ class PageImprovement
     {
       'subject' => path,
       'comment' => {
-        'body' => "[Details]\n#{description}\n\n[Name]\n#{name}\n\n[Email]\n#{email}\n\n[Path]\n#{path}\n\n[User agent]\n#{user_agent}"
+        'body' => ticket_body
       }
     }
   end
 
 private
   attr_reader :description, :email, :name, :path, :user_agent
+
+  def ticket_body
+    <<-TICKET_BODY.strip_heredoc
+      [Details]
+      #{description}
+
+      [Name]
+      #{name}
+
+      [Email]
+      #{email}
+
+      [Path]
+      #{path}
+
+      [User agent]
+      #{user_agent}
+    TICKET_BODY
+  end
 end

--- a/app/models/page_improvement.rb
+++ b/app/models/page_improvement.rb
@@ -1,10 +1,10 @@
 class PageImprovement
   include ActiveModel::Validations
 
-  validates_presence_of :description, :path
+  validates_presence_of :description, :url
 
   def initialize(attributes)
-    @path = attributes.fetch(:path, nil)
+    @url = attributes.fetch(:url, nil)
     @description = attributes.fetch(:description, nil)
     @name = attributes.fetch(:name, nil)
     @email = attributes.fetch(:email, nil)
@@ -13,7 +13,7 @@ class PageImprovement
 
   def zendesk_ticket_attributes
     {
-      'subject' => path,
+      'subject' => url,
       'comment' => {
         'body' => ticket_body
       }
@@ -21,7 +21,7 @@ class PageImprovement
   end
 
 private
-  attr_reader :description, :email, :name, :path, :user_agent
+  attr_reader :description, :email, :name, :url, :user_agent
 
   def ticket_body
     <<-TICKET_BODY.strip_heredoc
@@ -34,8 +34,8 @@ private
       [Email]
       #{email}
 
-      [Path]
-      #{path}
+      [URL]
+      #{url}
 
       [User agent]
       #{user_agent}

--- a/app/models/page_improvement.rb
+++ b/app/models/page_improvement.rb
@@ -8,17 +8,18 @@ class PageImprovement
     @description = attributes.fetch(:description, nil)
     @name = attributes.fetch(:name, nil)
     @email = attributes.fetch(:email, nil)
+    @user_agent = attributes.fetch(:user_agent, nil)
   end
 
   def zendesk_ticket_attributes
     {
       'subject' => path,
       'comment' => {
-        'body' => "[Details]\n#{description}\n\n[Name]\n#{name}\n\n[Email]\n#{email}\n\n[Path]\n#{path}"
+        'body' => "[Details]\n#{description}\n\n[Name]\n#{name}\n\n[Email]\n#{email}\n\n[Path]\n#{path}\n\n[User agent]\n#{user_agent}"
       }
     }
   end
 
 private
-  attr_reader :description, :email, :name, :path
+  attr_reader :description, :email, :name, :path, :user_agent
 end

--- a/app/models/page_improvement.rb
+++ b/app/models/page_improvement.rb
@@ -1,0 +1,24 @@
+class PageImprovement
+  include ActiveModel::Validations
+
+  validates_presence_of :description, :path
+
+  def initialize(attributes)
+    @path = attributes.fetch(:path, nil)
+    @description = attributes.fetch(:description, nil)
+    @name = attributes.fetch(:name, nil)
+    @email = attributes.fetch(:email, nil)
+  end
+
+  def zendesk_ticket_attributes
+    {
+      'subject' => path,
+      'comment' => {
+        'body' => "[Details]\n#{description}\n\n[Name]\n#{name}\n\n[Email]\n#{email}\n\n[Path]\n#{path}"
+      }
+    }
+  end
+
+private
+  attr_reader :description, :email, :name, :path
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,11 @@ Rails.application.routes.draw do
     get '/organisations/:slug', to: "organisations#show"
   end
 
+  resources 'page-improvements',
+            controller: 'page_improvements',
+            as: 'page_improvement',
+            only: [:create]
+
   resources :organisations,
             only: [:index, :show],
             format: false,

--- a/spec/models/page_improvement_spec.rb
+++ b/spec/models/page_improvement_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe PageImprovement, 'validations' do
-  it 'validates presence of path' do
+  it 'validates presence of url' do
     page_improvement = described_class.new({})
     page_improvement.valid?
 
-    expect(page_improvement.errors.messages).to include(path: include("can't be blank"))
+    expect(page_improvement.errors.messages).to include(url: include("can't be blank"))
   end
 
   it 'validates presence of description' do
@@ -19,7 +19,7 @@ end
 describe PageImprovement, '#zendesk_ticket_attributes' do
   it "generates a hash of attributes to create a Zendesk ticket" do
     page_improvement = described_class.new({
-      path: '/service-manual/test',
+      url: 'https://gov.uk/service-manual/test',
       description: 'I love this page.',
       name: 'John',
       email: 'john@example.com',
@@ -27,7 +27,7 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     })
 
     expect(page_improvement.zendesk_ticket_attributes).to eq({
-      'subject' => '/service-manual/test',
+      'subject' => 'https://gov.uk/service-manual/test',
       'comment' => {
         'body' => <<-TICKET_BODY.strip_heredoc
                     [Details]
@@ -39,8 +39,8 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
                     [Email]
                     john@example.com
 
-                    [Path]
-                    /service-manual/test
+                    [URL]
+                    https://gov.uk/service-manual/test
 
                     [User agent]
                     Safari
@@ -51,13 +51,13 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
 
   it "generates a hash of attributes where the body omits the optional name and email" do
     page_improvement = described_class.new({
-      path: '/service-manual/test',
+      url: 'https://gov.uk/service-manual/test',
       description: 'I love this page.',
       user_agent: 'Safari',
     })
 
     expect(page_improvement.zendesk_ticket_attributes).to eq({
-      'subject' => '/service-manual/test',
+      'subject' => 'https://gov.uk/service-manual/test',
       'comment' => {
         'body' => <<-TICKET_BODY.strip_heredoc
                     [Details]
@@ -69,8 +69,8 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
                     [Email]
 
 
-                    [Path]
-                    /service-manual/test
+                    [URL]
+                    https://gov.uk/service-manual/test
 
                     [User agent]
                     Safari

--- a/spec/models/page_improvement_spec.rb
+++ b/spec/models/page_improvement_spec.rb
@@ -29,7 +29,22 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari\n"
+        'body' => <<-TICKET_BODY.strip_heredoc
+                    [Details]
+                    I love this page.
+
+                    [Name]
+                    John
+
+                    [Email]
+                    john@example.com
+
+                    [Path]
+                    /service-manual/test
+
+                    [User agent]
+                    Safari
+                  TICKET_BODY
       }
     })
   end
@@ -44,7 +59,22 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari\n"
+        'body' => <<-TICKET_BODY.strip_heredoc
+                    [Details]
+                    I love this page.
+
+                    [Name]
+
+
+                    [Email]
+
+
+                    [Path]
+                    /service-manual/test
+
+                    [User agent]
+                    Safari
+                  TICKET_BODY
       }
     })
   end

--- a/spec/models/page_improvement_spec.rb
+++ b/spec/models/page_improvement_spec.rb
@@ -29,7 +29,7 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari"
+        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari\n"
       }
     })
   end
@@ -44,7 +44,7 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari"
+        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari\n"
       }
     })
   end

--- a/spec/models/page_improvement_spec.rb
+++ b/spec/models/page_improvement_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe PageImprovement, 'validations' do
+  it 'validates presence of path' do
+    page_improvement = described_class.new({})
+    page_improvement.valid?
+
+    expect(page_improvement.errors.messages).to include(path: include("can't be blank"))
+  end
+
+  it 'validates presence of description' do
+    page_improvement = described_class.new({})
+    page_improvement.valid?
+
+    expect(page_improvement.errors.messages).to include(description: include("can't be blank"))
+  end
+end
+
+describe PageImprovement, '#zendesk_ticket_attributes' do
+  it "generates a hash of attributes to create a Zendesk ticket" do
+    page_improvement = described_class.new({
+      path: '/service-manual/test',
+      description: 'I love this page.',
+      name: 'John',
+      email: 'john@example.com'
+    })
+
+    expect(page_improvement.zendesk_ticket_attributes).to eq({
+      'subject' => '/service-manual/test',
+      'comment' => {
+        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test"
+      }
+    })
+  end
+
+  it "generates a hash of attributes where the body omits the optional name and email" do
+    page_improvement = described_class.new({
+      path: '/service-manual/test',
+      description: 'I love this page.',
+    })
+
+    expect(page_improvement.zendesk_ticket_attributes).to eq({
+      'subject' => '/service-manual/test',
+      'comment' => {
+        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test"
+      }
+    })
+  end
+end

--- a/spec/models/page_improvement_spec.rb
+++ b/spec/models/page_improvement_spec.rb
@@ -22,13 +22,14 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
       path: '/service-manual/test',
       description: 'I love this page.',
       name: 'John',
-      email: 'john@example.com'
+      email: 'john@example.com',
+      user_agent: 'Safari',
     })
 
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test"
+        'body' => "[Details]\nI love this page.\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari"
       }
     })
   end
@@ -37,12 +38,13 @@ describe PageImprovement, '#zendesk_ticket_attributes' do
     page_improvement = described_class.new({
       path: '/service-manual/test',
       description: 'I love this page.',
+      user_agent: 'Safari',
     })
 
     expect(page_improvement.zendesk_ticket_attributes).to eq({
       'subject' => '/service-manual/test',
       'comment' => {
-        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test"
+        'body' => "[Details]\nI love this page.\n\n[Name]\n\n\n[Email]\n\n\n[Path]\n/service-manual/test\n\n[User agent]\nSafari"
       }
     })
   end

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -4,7 +4,7 @@ describe "Page Improvements" do
   it "responds succesfully" do
     stub_zendesk_ticket_creation
 
-    post '/page-improvements', { path: '/service-manual/agile', description: 'I have a problem' }
+    post '/page-improvements', { url: 'https://gov.uk/service-manual/test', description: 'I have a problem' }
 
     expect(response.code).to eq('201')
     expect(response_hash).to include('status' => 'success')
@@ -12,7 +12,7 @@ describe "Page Improvements" do
 
   it "sends the feedback to Zendesk" do
     zendesk_request = expect_zendesk_to_receive_ticket(
-      "subject" => "/service-manual/agile",
+      "subject" => "https://gov.uk/service-manual/test",
       "comment" => {
         "body" => <<-TICKET_BODY.strip_heredoc
                     [Details]
@@ -24,8 +24,8 @@ describe "Page Improvements" do
                     [Email]
                     john@example.com
 
-                    [Path]
-                    /service-manual/agile
+                    [URL]
+                    https://gov.uk/service-manual/test
 
                     [User agent]
                     Safari
@@ -34,7 +34,7 @@ describe "Page Improvements" do
     )
 
     post '/page-improvements', {
-      path: '/service-manual/agile',
+      url: 'https://gov.uk/service-manual/test',
       description: 'I have a problem',
       name: 'John',
       email: 'john@example.com',
@@ -45,14 +45,14 @@ describe "Page Improvements" do
   end
 
   it "responds unsuccessfully if the feedback isn't valid" do
-    post '/page-improvements', { path: '/service-manual/agile' }
+    post '/page-improvements', { url: 'https://gov.uk/service-manual/test' }
 
     expect(response.code).to eq('422')
     expect(response_hash).to include('status' => 'error')
   end
 
   it "returns errors if the feedback isn't valid" do
-    post '/page-improvements', { path: '/service-manual/agile' }
+    post '/page-improvements', { url: 'https://gov.uk/service-manual/test' }
 
     expect(response_hash).to include('errors' => include('description' => include("can't be blank")))
   end

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -14,7 +14,22 @@ describe "Page Improvements" do
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "/service-manual/agile",
       "comment" => {
-        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile\n\n[User agent]\nSafari\n"
+        "body" => <<-TICKET_BODY.strip_heredoc
+                    [Details]
+                    I have a problem
+
+                    [Name]
+                    John
+
+                    [Email]
+                    john@example.com
+
+                    [Path]
+                    /service-manual/agile
+
+                    [User agent]
+                    Safari
+                  TICKET_BODY
       }
     )
 

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -14,7 +14,7 @@ describe "Page Improvements" do
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "/service-manual/agile",
       "comment" => {
-        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile\n\n[User agent]\nSafari"
+        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile\n\n[User agent]\nSafari\n"
       }
     )
 

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe "Page Improvements" do
+  it "responds succesfully" do
+    stub_zendesk_ticket_creation
+
+    post '/page-improvements', { path: '/service-manual/agile', description: 'I have a problem' }
+
+    assert_response :success
+    expect(response_hash).to include('status' => 'success')
+  end
+
+  it "sends the feedback to Zendesk" do
+    zendesk_request = expect_zendesk_to_receive_ticket(
+      "subject" => "/service-manual/agile",
+      "comment" => {
+        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile"
+      }
+    )
+
+    post '/page-improvements', {
+      path: '/service-manual/agile',
+      description: 'I have a problem',
+      name: 'John',
+      email: 'john@example.com',
+    }
+
+    expect(zendesk_request).to have_been_made
+  end
+
+  it "responds unsuccessfully if the feedback isn't valid" do
+    post '/page-improvements', { path: '/service-manual/agile' }
+
+    expect(response.code).to eq('422')
+    expect(response_hash).to include('status' => 'error')
+  end
+
+  it "returns errors if the feedback isn't valid" do
+    post '/page-improvements', { path: '/service-manual/agile' }
+
+    expect(response_hash).to include('errors' => include('description' => include("can't be blank")))
+  end
+
+  def response_hash
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -6,7 +6,7 @@ describe "Page Improvements" do
 
     post '/page-improvements', { path: '/service-manual/agile', description: 'I have a problem' }
 
-    assert_response :success
+    expect(response.code).to eq('201')
     expect(response_hash).to include('status' => 'success')
   end
 

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -14,7 +14,7 @@ describe "Page Improvements" do
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "/service-manual/agile",
       "comment" => {
-        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile"
+        "body" => "[Details]\nI have a problem\n\n[Name]\nJohn\n\n[Email]\njohn@example.com\n\n[Path]\n/service-manual/agile\n\n[User agent]\nSafari"
       }
     )
 
@@ -23,6 +23,7 @@ describe "Page Improvements" do
       description: 'I have a problem',
       name: 'John',
       email: 'john@example.com',
+      user_agent: 'Safari',
     }
 
     expect(zendesk_request).to have_been_made


### PR DESCRIPTION
# Why

The service manual wants a way to allow users to give positive feedback, as well as negative.

# What

This receives feedback requests from the feedback frontend on behalf of the 'Improve this page' widget and forwards the feedback to Zendesk. https://trello.com/c/HN1L3EfK/286-update-footer-feedback-component

There isn't a requirement to browse the feedback anywhere apart from on Zendesk so we avoid the "Anonymous Feedback" flow in this app.

The 'Improve this page' feature is an experiment on the Service Manual. Traffic is expected to be very low. Therefore performance hasn't been taken seriously. Notably we are communicating with Zendesk synchronously. This will make the widget less snappy but has the advantage of being able to report to the user if it was successful.