### PR TITLE
Replace key with randomly generated version

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.
@@ -10,10 +11,10 @@
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
 
-# Although this is not needed for an api-only application, rails4 
-# requires secret_key_base or secret_token to be defined, otherwise an 
+# Although this is not needed for an api-only application, rails4
+# requires secret_key_base or secret_token to be defined, otherwise an
 # error is raised.
 # Using secret_token for rails3 compatibility. Change to secret_key_base
 # to avoid deprecation warning.
 # Can be safely removed in a rails3 api-only application.
-SupportApi::Application.config.secret_token = 'eb01a1852547cc0a573234e4e2f401bc6c05242a07f752752bb7bf8917598794eb8ac7f85cc8cc690c0124189fbaf9c93185cb807690c52b7e4cea8961831b0f'
+SupportApi::Application.config.secret_token = SecureRandom.hex(64)


### PR DESCRIPTION
As this is an API only app, the key shouldn't be used, but we need to define it
 anyway.