### PR TITLE
Refactor content item enrichment

### DIFF
--- a/app/workers/content_item_enrichment_worker.rb
+++ b/app/workers/content_item_enrichment_worker.rb
@@ -12,9 +12,15 @@ private
   def fetch_content_item(path)
     looked_up_item = SupportApi.content_item_lookup.lookup(path)
     if content_item = ContentItem.find_by(path: path)
-      content_item.tap { |item| item.organisations = looked_up_item.organisations } # refresh the orgs
+      content_item.tap { |item| item.organisations = build_orgs(looked_up_item.organisations) } # refresh the orgs
     else
-      looked_up_item
+      ContentItem.new(path: looked_up_item.path, organisations: build_orgs(looked_up_item.organisations))
+    end
+  end
+
+  def build_orgs(org_hashes)
+    org_hashes.map do |org_data|
+      Organisation.create_with(org_data).find_or_create_by(content_id: org_data[:content_id])
     end
   end
 end

--- a/lib/content_api_lookup.rb
+++ b/lib/content_api_lookup.rb
@@ -5,7 +5,11 @@ class ContentAPILookup
 
   def lookup(path)
     response = api_response(path)
-    ContentItem.new(path: URI(response["web_url"]).path, organisations: organisations_from(response)) if response
+
+    LookedUpContentItem.new(
+      path: URI(response['web_url']).path,
+      organisations: organisations_from(response),
+    ) if response.present?
   end
 
   def organisations_from(response)
@@ -19,15 +23,14 @@ class ContentAPILookup
 private
   def orgs_from_tags(tags)
     org_tags = tags.select {|t| t["details"]["type"] == "organisation" }
-    org_tags.map { |tag|
-      org_info = {
+    org_tags.map do |tag|
+      {
         content_id: tag["content_id"],
         slug: tag["slug"],
         web_url: tag["web_url"],
         title: tag["title"],
       }
-      Organisation.create_with(org_info).find_or_create_by(content_id: org_info[:content_id])
-    }
+    end
   end
 
   def api_response(path)

--- a/lib/content_item_lookup.rb
+++ b/lib/content_item_lookup.rb
@@ -1,14 +1,6 @@
 require 'content_api_lookup'
 require 'content_store_lookup'
-
-class LookedUpContentItem
-  attr_accessor :path, :organisations
-
-  def initialize(path:, organisations: [])
-    @path = path
-    @organisations = organisations
-  end
-end
+require 'looked_up_content_item'
 
 class ContentItemLookup
   def initialize(content_store:, content_api:)
@@ -20,14 +12,14 @@ class ContentItemLookup
     content_item = lookup_in_content_store_and_content_api(path) ||
       lookup_in_content_store_and_content_api(guess_alternate_path(path)) ||
       LookedUpContentItem.new(path: path)
-    content_item.tap { |item| item.organisations = guess_organisations_for(item.path) if item.organisations.empty? }
   end
 
 private
   def lookup_in_content_store_and_content_api(path)
-    content_store_item = @content_store_lookup.lookup(path)
-    content_api_item = @content_api_lookup.lookup(path)
-    build_item(content_store_item, content_api_item)
+    build_item(
+      @content_store_lookup.lookup(path),
+      @content_api_lookup.lookup(path),
+    )
   end
 
   def build_item(content_store_item, content_api_item)
@@ -50,33 +42,5 @@ private
 
   def take_segments_of(path, number:)
     URI(path).path.split("/").take(number + 1).join("/")
-  end
-
-  # ideally we can always find the content item in either the Content Store
-  # or the Content API, but in case we can't, determine a sensible default
-  def guess_organisations_for(path)
-    org_slug = if path =~ %r{^/government/world/organisations}
-                 case path
-                 when /dfid/ then "department-for-international-development"
-                 when /uk-trade-investment/ then "uk-trade-investment"
-                 else "foreign-commonwealth-office"
-                 end
-               elsif path =~ %r{^/government/organisations/hm-revenue-customs/contact}
-                 # TODO: remove this once Contacts Admin populates `links#organisations` in the Content Store
-                 "hm-revenue-customs"
-               else
-                 # if we can't determine the org of any content,
-                 # the owning organisation defaults to the owners of GOV.UK
-                 'government-digital-service'
-               end
-
-    org = Organisation.find_by!(slug: org_slug)
-
-    [{
-      content_id: org.content_id,
-      slug: org.slug,
-      web_url: org.web_url,
-      title: org.title,
-    }]
   end
 end

--- a/lib/looked_up_content_item.rb
+++ b/lib/looked_up_content_item.rb
@@ -1,0 +1,41 @@
+class LookedUpContentItem
+  attr_accessor :path
+
+  def initialize(path:, organisations: [])
+    @path = path
+    @organisations = organisations
+  end
+
+  def organisations
+    @organisations.any? ? @organisations : guess_organisations_for(path)
+  end
+
+private
+  # ideally we can always find the content item in either the Content Store
+  # or the Content API, but in case we can't, determine a sensible default
+  def guess_organisations_for(path)
+    org_slug = if path =~ %r{^/government/world/organisations}
+                 case path
+                 when /dfid/ then "department-for-international-development"
+                 when /uk-trade-investment/ then "uk-trade-investment"
+                 else "foreign-commonwealth-office"
+                 end
+               elsif path =~ %r{^/government/organisations/hm-revenue-customs/contact}
+                 # TODO: remove this once Contacts Admin populates `links#organisations` in the Content Store
+                 "hm-revenue-customs"
+               else
+                 # if we can't determine the org of any content,
+                 # the owning organisation defaults to the owners of GOV.UK
+                 "government-digital-service"
+               end
+
+    org = Organisation.find_by!(slug: org_slug)
+
+    [{
+      content_id: org.content_id,
+      slug: org.slug,
+      web_url: org.web_url,
+      title: org.title,
+    }]
+  end
+end

--- a/lib/looked_up_content_item.rb
+++ b/lib/looked_up_content_item.rb
@@ -20,9 +20,6 @@ private
                  when /uk-trade-investment/ then "uk-trade-investment"
                  else "foreign-commonwealth-office"
                  end
-               elsif path =~ %r{^/government/organisations/hm-revenue-customs/contact}
-                 # TODO: remove this once Contacts Admin populates `links#organisations` in the Content Store
-                 "hm-revenue-customs"
                else
                  # if we can't determine the org of any content,
                  # the owning organisation defaults to the owners of GOV.UK

--- a/spec/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/workers/content_item_enrichment_worker_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/content_api'
+
+describe ContentItemEnrichmentWorker do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::ContentApi
+
+  let(:raw_path) { 'my-magic-govuk-endpoint' }
+  let(:path) { "/#{raw_path}" }
+  let(:problem_report) { create(:problem_report, path: path) }
+  subject(:worker) { described_class.new }
+
+  context "with an entry in both the content api and content store" do
+    before do
+      create(:gds)
+      content_store_has_item(path)
+      content_api_has_an_artefact(raw_path)
+    end
+
+    context "without an existing content item" do
+      it "creates a new content item" do
+        expect(ContentItem.count).to eq(0)
+        worker.perform(problem_report.id)
+        expect(ContentItem.count).to eq(1)
+      end
+    end
+
+    context "with an existing content item" do
+      it "uses the existing content item" do
+        create(:content_item, path: path)
+
+        expect { worker.perform(problem_report.id) }.to_not change { ContentItem.count }
+      end
+    end
+  end
+
+  context "with an entry in the content api" do
+    before do
+      create(:gds)
+      content_store_does_not_have_item(path)
+      content_api_has_an_artefact(raw_path)
+    end
+
+    context "without an existing content item" do
+      it "creates a new content item" do
+        expect(ContentItem.count).to eq(0)
+        worker.perform(problem_report.id)
+        expect(ContentItem.count).to eq(1)
+      end
+    end
+
+    context "with an existing content item" do
+      it "uses the existing content item" do
+        create(:content_item, path: path)
+
+        expect { worker.perform(problem_report.id) }.to_not change { ContentItem.count }
+      end
+    end
+  end
+
+  context "with an entry in the content store" do
+    before do
+      create(:gds)
+      content_store_has_item(path)
+      content_api_does_not_have_an_artefact(raw_path)
+    end
+
+    context "without an existing content item" do
+      it "creates a new content item" do
+        expect(ContentItem.count).to eq(0)
+        worker.perform(problem_report.id)
+        expect(ContentItem.count).to eq(1)
+      end
+    end
+
+    context "with an existing content item" do
+      it "uses the existing content item" do
+        create(:content_item, path: path)
+
+        expect { worker.perform(problem_report.id) }.to_not change { ContentItem.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The content item enrichment is ending up with multiple content items with the same path in the database. This makes no sense.

I've not been able to work out why -- the code seemed pretty straightforward.

Instead, I've refactored how content item lookups happen so that they return data structures only, which are then interpreted into the database records in a single place (the enrichment worker). This means that there can't be any side effects outside this class that result in duplicates being created.

This should reduce the frequency of it happening again while I bash my head against a brick wall trying to figure out why.