### PR TITLE
Fix missing date_parser require

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,3 +1,5 @@
+require 'date_parser'
+
 class AnonymousFeedbackController < ApplicationController
   def index
     unless params[:organisation_slug].present? || params[:path_prefix].present?


### PR DESCRIPTION
We have some classes used by the rails app inside of lib. Controllers
explicitly require these classes but in this case the AnonymousFeedbackController
didn’t.

This was causing an error when running locally, but doesn’t surface on
deployed environments because they run in production mode which will
eager load.

In lieu of refactoring to put these classes in the app folder, this just
updates the controller to require the DateParser class.