### PR TITLE
Provide rake task to fix misreported done page service feedback

### DIFF
--- a/lib/fix_misreported_done_page_service_feedback.rb
+++ b/lib/fix_misreported_done_page_service_feedback.rb
@@ -1,0 +1,42 @@
+class FixMisreportedDonePageServiceFeedback
+  def initialize(start_date, end_date, logger)
+    @start_date = start_date
+    @end_date = end_date
+    @logger = logger
+  end
+
+  def fix_all!
+    all_done_page_paths.each do |done_page_path|
+      service_slug = done_page_path.gsub("/done/", '')
+      fix!(service_slug)
+    end
+  end
+
+  def fix!(service_slug)
+    done_page_path = "/done/#{service_slug}"
+    logger.info("Investigating `#{done_page_path}` for misreported service feedback between #{start_date} and #{end_date}")
+
+    [ServiceFeedback, AggregatedServiceFeedback].each do |feedback_type|
+      misreported_service_feedback = fetch_misreported_service_feedback(service_slug, for_feedback_type: feedback_type)
+
+      if misreported_service_feedback.count > 0
+        logger.info("Fixing #{misreported_service_feedback.count} #{feedback_type.name} records for `#{done_page_path}`")
+        misreported_service_feedback.update_all(path: done_page_path)
+      else
+        logger.info("No #{feedback_type.name} for `#{done_page_path}` was misreported")
+      end
+    end
+  end
+
+private
+
+  attr_reader :logger, :start_date, :end_date
+
+  def all_done_page_paths
+    @all_done_page_paths ||= ServiceFeedback.matching_path_prefix('/done').select(:path).distinct.pluck(:path)
+  end
+
+  def fetch_misreported_service_feedback(service_slug, for_feedback_type: ServiceFeedback)
+    for_feedback_type.created_between_days(start_date, end_date).where(path: "/#{service_slug}")
+  end
+end

--- a/lib/tasks/fix_misreported_service_feedback.rake
+++ b/lib/tasks/fix_misreported_service_feedback.rake
@@ -1,0 +1,28 @@
+namespace :fix_misreported_service_feedback do
+  desc "Moves service feedback from /service-name to /done/service-name (for a period the feedback was submitted with the wrong path for /done pages)"
+  task :all, [:start_date_string, :end_date_string] => :environment do |_t, args|
+    require File.join(Rails.root, 'lib', 'fix_misreported_done_page_service_feedback')
+
+    raise 'Start and end date required' unless args[:start_date_string] && args[:end_date_string]
+
+    start_date = Date.parse(args[:start_date_string])
+    end_date = Date.parse(args[:end_date_string])
+
+    logger = Logger.new("#{Rails.root}/log/fix_misreported_service_feedback.log")
+    fixer = FixMisreportedDonePageServiceFeedback.new(start_date, end_date, logger)
+    fixer.fix_all!
+  end
+
+  task :one, [:start_date_string, :end_date_string, :slug] => :environment do |_t, args|
+    require File.join(Rails.root, 'lib', 'fix_misreported_done_page_service_feedback')
+
+    raise 'Start date, end date, and slug required' unless args[:start_date_string] && args[:end_date_string] && args[:slug]
+
+    start_date = Date.parse(args[:start_date_string])
+    end_date = Date.parse(args[:end_date_string])
+
+    logger = Logger.new("#{Rails.root}/log/fix_misreported_service_feedback.log")
+    fixer = FixMisreportedDonePageServiceFeedback.new(start_date, end_date, logger)
+    fixer.fix!(args[:slug])
+  end
+end

--- a/spec/lib/fix_misreported_done_page_service_feedback_spec.rb
+++ b/spec/lib/fix_misreported_done_page_service_feedback_spec.rb
@@ -1,0 +1,170 @@
+require 'fix_misreported_done_page_service_feedback'
+require 'rails_helper'
+
+RSpec.describe FixMisreportedDonePageServiceFeedback do
+  let(:start_date) { Date.new(2014, 6, 10) }
+  let(:inbetween_date) { start_date + 5 }
+  let(:end_date) { start_date + 10 }
+  let(:test_logger) { Rails.logger }
+
+  subject { described_class.new(start_date, end_date, test_logger) }
+
+  describe '#fix!' do
+    let(:service_slug) { 'register-to-vote' }
+    context 'for ServiceFeedback instances' do
+      context 'with "/done"-less version of supplied path' do
+        context 'created before the start date' do
+          let!(:service_feedback) do
+            FactoryGirl.create(
+              :service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: start_date - 10,
+            )
+          end
+
+          it 'does not have its path changed' do
+            subject.fix!(service_slug)
+            expect(service_feedback.reload.path).not_to eq "/done/#{service_slug}"
+          end
+        end
+
+        context 'created after the end date' do
+          let!(:service_feedback) do
+            FactoryGirl.create(
+              :service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: end_date + 10,
+            )
+          end
+
+          it 'does not have its path changed' do
+            subject.fix!(service_slug)
+            expect(service_feedback.reload.path).not_to eq "/done/#{service_slug}"
+          end
+        end
+
+        context 'created between the start and end dates' do
+          let!(:service_feedback) do
+            FactoryGirl.create(
+              :service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: inbetween_date,
+            )
+          end
+
+          it 'has its path changed to the /done version' do
+            subject.fix!(service_slug)
+            expect(service_feedback.reload.path).to eq "/done/#{service_slug}"
+          end
+        end
+      end
+
+      it 'ignores those having paths with suffixes of the supplied service' do
+        service_feedback = FactoryGirl.create(
+          :service_feedback,
+          service_satisfaction_rating: 1,
+          slug: 'register-to-vote-abroad',
+          path: "/register-to-vote-abroad",
+          created_at: inbetween_date,
+        )
+
+        subject.fix!('register-to-vote')
+        expect(service_feedback.reload.path).not_to eq "/done/register-to-vote"
+      end
+    end
+
+    context 'for AggregatedServiceFeedback instances' do
+      context 'with "/done"-less version of supplied path' do
+        context 'created before the start date' do
+          let!(:aggregated_service_feedback) do
+            FactoryGirl.create(
+              :aggregated_service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: start_date - 10,
+            )
+          end
+
+          it 'does not have its path changed' do
+            subject.fix!(service_slug)
+            expect(aggregated_service_feedback.reload.path).not_to eq "/done/#{service_slug}"
+          end
+        end
+
+        context 'created after the end date' do
+          let!(:aggregated_service_feedback) do
+            FactoryGirl.create(
+              :aggregated_service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: end_date + 10,
+            )
+          end
+
+          it 'does not have its path changed' do
+            subject.fix!(service_slug)
+            expect(aggregated_service_feedback.reload.path).not_to eq "/done/#{service_slug}"
+          end
+        end
+
+        context 'created between the start and end dates' do
+          let!(:aggregated_service_feedback) do
+            FactoryGirl.create(
+              :aggregated_service_feedback,
+              service_satisfaction_rating: 1,
+              slug: service_slug,
+              path: "/#{service_slug}",
+              created_at: inbetween_date,
+            )
+          end
+
+          it 'has its path changed to the /done version' do
+            subject.fix!(service_slug)
+            expect(aggregated_service_feedback.reload.path).to eq "/done/#{service_slug}"
+          end
+        end
+      end
+
+      it 'ignores those having paths with suffixes of the supplied service' do
+        aggregated_service_feedback = FactoryGirl.create(
+          :aggregated_service_feedback,
+          service_satisfaction_rating: 1,
+          slug: 'register-to-vote-abroad',
+          path: "/register-to-vote-abroad",
+          created_at: inbetween_date,
+        )
+
+        subject.fix!('register-to-vote')
+        expect(aggregated_service_feedback.reload.path).not_to eq "/done/register-to-vote"
+      end
+    end
+  end
+
+  describe '#fix_all!' do
+    let!(:done_page_1) { FactoryGirl.create(:service_feedback, path: '/done/service-1') }
+    let!(:done_page_2) { FactoryGirl.create(:service_feedback, path: '/done/service-2') }
+    let!(:done_page_3) { FactoryGirl.create(:long_form_contact, path: '/done/service-3', details: 'Hi there') }
+    let!(:misreported_feedback_for_done_page_1) { FactoryGirl.create(:service_feedback, slug: 'service-1', path: '/service-1', created_at: inbetween_date) }
+    let!(:misreported_feedback_for_done_page_2) { FactoryGirl.create(:service_feedback, slug: 'service-2', path: '/service-2', created_at: inbetween_date) }
+    let!(:misreported_feedback_for_done_page_3) { FactoryGirl.create(:service_feedback, slug: 'service-3', path: '/service-3', created_at: inbetween_date) }
+
+    it 'fixes misreported feedback for all /done pages that have service feedback' do
+      subject.fix_all!
+      expect(misreported_feedback_for_done_page_1.reload.path).to eq '/done/service-1'
+      expect(misreported_feedback_for_done_page_2.reload.path).to eq '/done/service-2'
+    end
+
+    it 'ignores misreported feedback for a /done page that has no service feedback' do
+      subject.fix_all!
+      expect(misreported_feedback_for_done_page_3.reload.path).not_to eq '/done/service-3'
+    end
+  end
+end


### PR DESCRIPTION
For a couple of weeks in March 2017 the done page template sent the
service feedback form submissions to the support-api with the wrong
path - it used the slug of the service instead of the full path to
the done page (e.g. register-to-vote instead of /done/register-to-vote).
This meant that the service feedback was stored against the incorrect
url and couldn't be found in the feedback explorer for the done page.

Here we introduce an object that given a set of dates and a slug will
re-assign any service feedback (and aggregated service feedback) for
`/slug` to `/done/slug`.  There's also a version that will extract all
done pages that have some service feedback and fix all of them.

This feels safe to do because none of the /slug pages had a form on
them for submitting service feedback during the couple of weeks in
March so all service feedback in the db for /slug during that time
really is for /done/slug.  There are service feedback entries in the db
for some /slug pages outside those dates, but it's hard to know if those
are errors from similar bugs in the past, or from versions of the site
that did have service feedback forms on the /slug pages.  When we run
this script we'll limit it to 1st March 2017 to 1st April 2017.

For: https://trello.com/c/xZ97pseN/160-fix-data-in-feedex-for-done-pages-from-2nd-to-20th-march-2017