### PR TITLE
Remove references to the Content API

### DIFF
--- a/lib/looked_up_content_item.rb
+++ b/lib/looked_up_content_item.rb
@@ -12,7 +12,7 @@ class LookedUpContentItem
 
 private
   # ideally we can always find the content item in either the Content Store
-  # or the Content API, but in case we can't, determine a sensible default
+  # but in case we can't, determine a sensible default
   def guess_organisations_for(path)
     org_slug = if path =~ %r{^/government/world/organisations}
                  case path

--- a/spec/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/workers/content_item_enrichment_worker_spec.rb
@@ -9,7 +9,7 @@ describe ContentItemEnrichmentWorker do
   let(:problem_report) { create(:problem_report, path: path) }
   subject(:worker) { described_class.new }
 
-  context "with an entry in both the content api and content store" do
+  context "with an entry in the content store" do
     before do
       create(:gds)
       content_store_has_item(path)


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api
