### PR TITLE
Push fixed misreported service feedback to performance platform

### DIFF
--- a/lib/fix_misreported_done_page_service_feedback.rb
+++ b/lib/fix_misreported_done_page_service_feedback.rb
@@ -17,8 +17,8 @@ class FixMisreportedDonePageServiceFeedback
     logger.info("Investigating `#{done_page_path}` for misreported service feedback between #{start_date} and #{end_date}")
 
     fix_feedback(ServiceFeedback, service_slug, done_page_path)
-    fix_feedback(AggregatedServiceFeedback, service_slug, done_page_path)
-
+    aggregated_feedback_fixed = fix_feedback(AggregatedServiceFeedback, service_slug, done_page_path)
+    push_to_peformance_plaftorm(service_slug) if aggregated_feedback_fixed > 0
   end
 
 private
@@ -45,5 +45,20 @@ private
     end
 
     how_many_to_fix
+  end
+
+  def date_range_for_feedback
+    start_date..end_date
+  end
+
+  def push_to_peformance_plaftorm(service_slug)
+    date_range_for_feedback.to_a.each do |feedback_date|
+      begin
+        ServiceFeedbackPPUploaderWorker.new.perform(feedback_date.year, feedback_date.month, feedback_date.day, service_slug)
+        logger.info("Pushing aggregated `#{service_slug}` feedback for #{feedback_date.iso8601} to performance platform")
+      rescue RuntimeError => e
+        raise unless e.message == "Aggregated feedback items not found!"
+      end
+    end
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/xZ97pseN/160-fix-data-in-feedex-for-done-pages-from-2nd-to-20th-march-2017

The system only pushes yesterday's aggregated service feedback to the
performance platform and doesn't look for changes it hasn't handled. This
means that after fixing the slugs in the aggregated feedback (see #110) we 
have to send it to the performance platform manually.  We do this inline 
rather than run them as jobs to get immediate feedback.

We don't need to remove the old data from the performance platform
as it would never have been sent.  The code that gets the aggregated
details for sending them to the perf platform will only load data for
`/done/` paths and the misreported feedback didn't have `/done/` in
the path so wouldn't have been sent.
