### PR TITLE
Add org details to feedback csv

### DIFF
--- a/app/presenters/feedback_csv_row_presenter.rb
+++ b/app/presenters/feedback_csv_row_presenter.rb
@@ -3,8 +3,11 @@ require 'user_agent_parser'
 class FeedbackCsvRowPresenter
   attr_reader :row
 
-  HEADER_ROW = ["creation date", "path or service name", "feedback", "service satisfaction rating",
-                "browser name", "browser version", "browser platform", "user agent", "referrer", "type"]
+  HEADER_ROW = [
+    "creation date", "path or service name", "feedback", "service satisfaction rating",
+    "browser name", "browser version", "browser platform", "user agent", "referrer", "type",
+    "primary organisation", "all organisations"
+  ].freeze
 
   def self.parser
     Thread.current[:user_agent_parser] ||= UserAgentParser::Parser.new
@@ -25,7 +28,9 @@ class FeedbackCsvRowPresenter
       parsed_user_agent.os.family,
       row.user_agent,
       row.referrer,
-      row.type
+      row.type,
+      primary_organisation,
+      all_organisations
     ]
   end
 
@@ -52,5 +57,13 @@ class FeedbackCsvRowPresenter
     else
       ""
     end
+  end
+
+  def primary_organisation
+    row.organisations.first.try(:title) || ""
+  end
+
+  def all_organisations
+    row.organisations.map(&:title).join("|")
   end
 end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe FeedbackExportRequest, type: :model do
     end
 
     it "uses the FeedbackCsvRowPresenter to format the row" do
-      header = "creation date,path or service name,feedback,service satisfaction rating,browser name,browser version,browser platform,user agent,referrer,type"
+      header = "creation date,path or service name,feedback,service satisfaction rating,browser name,browser version,browser platform,user agent,referrer,type,primary organisation,all organisations"
       allow_any_instance_of(FeedbackCsvRowPresenter).to receive(:to_a).and_return(["a", "b", "c"])
       expect(subject.string).to eq "#{header}\na,b,c\na,b,c\n"
     end

--- a/spec/presenters/feedback_csv_row_presenter_spec.rb
+++ b/spec/presenters/feedback_csv_row_presenter_spec.rb
@@ -107,5 +107,13 @@ describe FeedbackCsvRowPresenter do
 
       it { is_expected.to eq("It was really good\nReally.\nGood job") }
     end
+
+    context "for aggregated service feedback" do
+      let(:row) { aggregated_service_feedback }
+
+      it 'is a sentence explaining the rating and how many ratings there were' do
+        expect(subject).to eq("Rating of 3: 1")
+      end
+    end
   end
 end

--- a/spec/presenters/feedback_csv_row_presenter_spec.rb
+++ b/spec/presenters/feedback_csv_row_presenter_spec.rb
@@ -24,7 +24,9 @@ describe FeedbackCsvRowPresenter do
           "Windows Vista",
           row.user_agent,
           "http://www.example.com/foo",
-          "problem-report"
+          "problem-report",
+          "",
+          ""
         ]
       end
     end
@@ -43,7 +45,9 @@ describe FeedbackCsvRowPresenter do
           "Windows Vista",
           row.user_agent,
           "http://www.example.com/foo",
-          "service-feedback"
+          "service-feedback",
+          "",
+          ""
         ]
       end
     end
@@ -61,7 +65,9 @@ describe FeedbackCsvRowPresenter do
           "Windows Vista",
           row.user_agent,
           "http://www.example.com/foo",
-          "aggregated-service-feedback"
+          "aggregated-service-feedback",
+          "",
+          ""
         ]
       end
     end
@@ -80,8 +86,102 @@ describe FeedbackCsvRowPresenter do
           "Windows Vista",
           row.user_agent,
           "http://www.example.com/foo",
-          "long-form-contact"
+          "long-form-contact",
+          "",
+          ""
         ]
+      end
+    end
+  end
+
+  describe "#primary_organisation" do
+    subject { instance.primary_organisation }
+    let(:row) { create(:anonymous_contact, content_item: content_item) }
+
+    context "for feedback with no content item" do
+      let(:content_item) { nil }
+
+      it "is the empty string" do
+        expect(subject).to eq ""
+      end
+    end
+
+    context "for feedback with a content item" do
+      let(:content_item) { build(:content_item, organisations: organisations) }
+
+      context "that has no organisations" do
+        let(:organisations) { [] }
+
+        it "is the empty string" do
+          expect(subject).to eq ""
+        end
+      end
+
+      context "for feedback with a content item has one organisation" do
+        let(:organisations) { [build(:organisation, title: "Department for Ursine Affairs")] }
+
+        it "is that organisation's title" do
+          expect(subject).to eq "Department for Ursine Affairs"
+        end
+      end
+
+      context "for feedback with a content item has more than one organisations" do
+        let(:organisations) {
+          [
+            build(:organisation, title: "Apiarian Embassy"),
+            build(:organisation, title: "Department for Ursine Affairs")
+          ]
+        }
+
+        it "is the first organisation's title" do
+          expect(subject).to eq "Apiarian Embassy"
+        end
+      end
+    end
+  end
+
+  describe "#all_organisations" do
+    subject { instance.all_organisations }
+    let(:row) { create(:anonymous_contact, content_item: content_item) }
+
+    context "for feedback with no content item" do
+      let(:content_item) { nil }
+
+      it "is the empty string" do
+        expect(subject).to eq ""
+      end
+    end
+
+    context "for feedback with a content item" do
+      let(:content_item) { build(:content_item, organisations: organisations) }
+
+      context "that has no organisations" do
+        let(:organisations) { [] }
+
+        it "is the empty string" do
+          expect(subject).to eq ""
+        end
+      end
+
+      context "for feedback with a content item has one organisation" do
+        let(:organisations) { [build(:organisation, title: "Department for Ursine Affairs")] }
+
+        it "is that organisation's title" do
+          expect(subject).to eq "Department for Ursine Affairs"
+        end
+      end
+
+      context "for feedback with a content item has more than one organisations" do
+        let(:organisations) {
+          [
+            build(:organisation, title: "Apiarian Embassy"),
+            build(:organisation, title: "Department for Ursine Affairs")
+          ]
+        }
+
+        it "is the all the organisation's titles separated by `|`" do
+          expect(subject).to eq "Apiarian Embassy|Department for Ursine Affairs"
+        end
       end
     end
   end


### PR DESCRIPTION
For: https://trello.com/c/wuROphQ5/175-add-org-column-to-feedex-reports-was-one-off-report-feedex

We add "primary organisation" and "all organisations" columns to the feedback CSV.  This is in response to a request for a one-off report that we might as well make available to all reports.