### PR TITLE
Be more lenient on the referrers we accept

### DIFF
--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -7,7 +7,7 @@ class AnonymousContact < ApplicationRecord
   belongs_to :content_item, optional: true
   has_many :organisations, through: :content_item
 
-  validates :referrer, url: true, length: { maximum: 2048 }, allow_nil: true
+  validates :referrer, referrer_url: true, length: { maximum: 2048 }, allow_nil: true
   validates :path,     url: true, length: { maximum: 2048 }, presence: true
   validates :user_agent, length: { maximum: 2048 }
   validates :details, length: { maximum: 2 ** 16 }

--- a/app/validators/referrer_url_validator.rb
+++ b/app/validators/referrer_url_validator.rb
@@ -1,0 +1,11 @@
+class ReferrerUrlValidator < UrlValidator
+  # Referrer URLs can come from a variety of places
+  # eg web URLs as well as app URLs such as
+  # android-app://com.google.android.googlequicksearchbox
+  # Simply check the URL can be parsed
+  def url_valid?(url)
+    !!URI.parse(url)
+  rescue
+    false
+  end
+end

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -59,6 +59,7 @@ describe AnonymousContact, :type => :model do
     it { should allow_value("http://" + ("a" * 2040)).for(:referrer) }
     it { should_not allow_value("http://" + ("a" * 2050)).for(:referrer) }
     it { should_not allow_value("http://bla.example.org:9292/méh/fào?bar").for(:referrer) }
+    it { should allow_value("android-app://com.google.android.googlequicksearchbox").for(:referrer) }
   end
 
   context "when duplicates are present" do


### PR DESCRIPTION
Only check that a URI can be parsed.

Referrer URLs can come from a variety of places eg web URLs as well as
app URLs such as “android-app://com.google.android.googlequicksearchbox”

Before this change we were rejecting otherwise valid feedback from
Android users.

https://trello.com/c/lF8Yated/66-2-http-feedback-frontend-error
https://errbit.publishing.service.gov.uk/apps/5319fd4f0da11511b00017c3/problems/597880526578634a2e330200