### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This API:
 - accepts and stores GOV.UK-related requests from the public (end-users) and from departmental users
 - manages anonymous feedback raised on GOV.UK
 
-This is a Rails (4) application.
+This is a Rails 5 application.
 
 ## Specs
 


### PR DESCRIPTION
`This is a Rails (4) application.`

Not any more.