### PR TITLE
Stop raising when no aggregate feedback

### DIFF
--- a/app/workers/service_feedback_pp_uploader_worker.rb
+++ b/app/workers/service_feedback_pp_uploader_worker.rb
@@ -18,7 +18,9 @@ class ServiceFeedbackPPUploaderWorker
       slug: transaction_slug,
     ).call
 
-    api.submit_service_feedback_day_aggregate(transaction_slug, payload)
+    unless payload["total"].nil?
+      api.submit_service_feedback_day_aggregate(transaction_slug, payload)
+    end
   rescue GdsApi::PerformancePlatformDatasetNotConfigured => e
     Rails.logger.warn(e.message)
   end

--- a/lib/fix_misreported_done_page_service_feedback.rb
+++ b/lib/fix_misreported_done_page_service_feedback.rb
@@ -53,12 +53,8 @@ private
 
   def push_to_peformance_plaftorm(service_slug)
     date_range_for_feedback.to_a.each do |feedback_date|
-      begin
-        ServiceFeedbackPPUploaderWorker.new.perform(feedback_date.year, feedback_date.month, feedback_date.day, service_slug)
-        logger.info("Pushing aggregated `#{service_slug}` feedback for #{feedback_date.iso8601} to performance platform")
-      rescue RuntimeError => e
-        raise unless e.message == "Aggregated feedback items not found!"
-      end
+      ServiceFeedbackPPUploaderWorker.new.perform(feedback_date.year, feedback_date.month, feedback_date.day, service_slug)
+      logger.info("Pushing aggregated `#{service_slug}` feedback for #{feedback_date.iso8601} to performance platform")
     end
   end
 end

--- a/lib/performance_platform_service_feedback_metrics.rb
+++ b/lib/performance_platform_service_feedback_metrics.rb
@@ -36,8 +36,6 @@ private
     aggregated_feedback_items = AggregatedServiceFeedback.
       where(path: path, created_at: time_interval)
 
-    raise "Aggregated feedback items not found!" if aggregated_feedback_items.count == 0
-
     aggregated_feedback_items.inject({}) do |memo, item|
       memo[item.service_satisfaction_rating] = item.details.to_i
       memo

--- a/spec/lib/fix_misreported_done_page_service_feedback_spec.rb
+++ b/spec/lib/fix_misreported_done_page_service_feedback_spec.rb
@@ -155,11 +155,12 @@ RSpec.describe FixMisreportedDonePageServiceFeedback do
             expect(perf_platform_request).to have_been_requested
           end
 
-          it 'swallows "no aggregates found" raised by calculating the data for each day' do
-            allow_any_instance_of(PerformancePlatformServiceFeedbackMetrics).to receive(:call).and_raise(RuntimeError, "Aggregated feedback items not found!")
-            expect {
-              subject.fix!(service_slug)
-            }.not_to raise_error
+        end
+
+        context 'no aggregate data returned' do
+          it 'doesn\'t send' do
+            subject.fix!(service_slug)
+            expect(perf_platform_request).not_to have_been_requested
           end
         end
       end

--- a/spec/lib/performance_platform_service_feedback_metrics_spec.rb
+++ b/spec/lib/performance_platform_service_feedback_metrics_spec.rb
@@ -6,21 +6,6 @@ describe PerformancePlatformServiceFeedbackMetrics do
     described_class.new(day: Date.new(2013, 2, 10), slug: 'apply-carers-allowance')
   }
 
-  context "without any aggregated feedback for that day" do
-    before do
-      create(:aggregated_service_feedback,
-             service_satisfaction_rating: 1,
-             slug: "abcde",
-             created_at: Date.new(2013,2,9),
-             details: 1,
-            )
-    end
-
-    it "raises an error" do
-      expect { metric_generator.call }.to raise_error("Aggregated feedback items not found!")
-    end
-  end
-
   context "with valid aggregated feedback" do
     before do
       create(:aggregated_service_feedback,


### PR DESCRIPTION
When aggregate feedback for a time period is empty we were raising an exception, seemingly to halt the flow and prevent the empty data being sent to performance platform. There was a test that checked that the error was swallowed when it was raised but not all callers of the code
were catching the error. This was causing it to be raised within the worker and then reported multiple times to Sentry when the job was retried.

This commit removes the exception and checks the `total` value from the payload instead using that to decide whether to send to performance platform or not.

[Trello](https://trello.com/c/btVExJP7/379-identify-and-fix-high-volume-sentry-errors)