### PR TITLE
Add search by format and by multiple paths

### DIFF
--- a/app/controllers/anonymous_feedback/document_types_controller.rb
+++ b/app/controllers/anonymous_feedback/document_types_controller.rb
@@ -1,0 +1,29 @@
+module AnonymousFeedback
+  class DocumentTypesController < ApplicationController
+    def index
+      render json: ContentItem.all_document_types
+    end
+
+    def show
+      ordering = if %w(path last_7_days last_30_days last_90_days).include? params[:ordering]
+                   params[:ordering]
+                 else
+                   'last_7_days'
+                 end
+
+      unless ContentItem.for_document_type(params[:document_type]).any?
+        head :not_found
+        return
+      end
+
+      anonymous_feedback_counts = ContentItem.
+          where(document_type: params[:document_type]).
+          summary(ordering)
+
+      render json: {
+          document_type: params[:document_type],
+          anonymous_feedback_counts: anonymous_feedback_counts,
+      }
+    end
+  end
+end

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -28,7 +28,7 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   private
     def export_request_params
-      permitted_params = [:from, :to, :organisation, :notification_email, :path_prefix, path_prefixes: []]
+      permitted_params = [:from, :to, :organisation, :notification_email, :document_type, :path_prefix, path_prefixes: []]
       clean_params = params.require(:export_request).permit(*permitted_params).to_h
       if clean_params[:path_prefix].present?
         clean_params[:path_prefixes] = [clean_params[:path_prefix]]
@@ -40,7 +40,8 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
           from: DateParser.parse(clean_params[:from]),
           to: DateParser.parse(clean_params[:to]),
           path_prefixes: clean_params[:path_prefixes],
-          organisation_slug: clean_params[:organisation]
+          organisation_slug: clean_params[:organisation],
+          document_type: clean_params[:document_type]
         },
         notification_email: clean_params[:notification_email]
       }

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -1,3 +1,5 @@
+require 'date_parser'
+
 class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   def create
@@ -26,13 +28,18 @@ class AnonymousFeedback::ExportRequestsController < ApplicationController
 
   private
     def export_request_params
-      permitted_params = %i(from to path_prefix organisation notification_email)
+      permitted_params = [:from, :to, :organisation, :notification_email, :path_prefix, path_prefixes: []]
       clean_params = params.require(:export_request).permit(*permitted_params).to_h
+      if clean_params[:path_prefix].present?
+        clean_params[:path_prefixes] = [clean_params[:path_prefix]]
+        clean_params.delete(:path_prefix)
+      end
+
       {
         filters: {
           from: DateParser.parse(clean_params[:from]),
           to: DateParser.parse(clean_params[:to]),
-          path_prefix: clean_params[:path_prefix],
+          path_prefixes: clean_params[:path_prefixes],
           organisation_slug: clean_params[:organisation]
         },
         notification_email: clean_params[:notification_email]

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -4,7 +4,7 @@ class AnonymousFeedbackController < ApplicationController
   before_action :clean_params
 
   def index
-    unless params[:organisation_slug].present? || params[:path_prefixes].present?
+    unless at_least_one_param_present?
       head :bad_request
       return
     end
@@ -26,10 +26,15 @@ class AnonymousFeedbackController < ApplicationController
 
   private
 
+  def at_least_one_param_present?
+    params[:organisation_slug].present? || params[:path_prefixes].present? || params[:document_type].present?
+  end
+
   def scope
     AnonymousContact.
       for_query_parameters(path_prefixes: params[:path_prefixes],
                            organisation_slug: params[:organisation_slug],
+                           document_type: params[:document_type],
                            from: dates[0],
                            to: dates[1]).
       most_recent_first

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,8 +1,10 @@
 require 'date_parser'
 
 class AnonymousFeedbackController < ApplicationController
+  before_action :clean_params
+
   def index
-    unless params[:organisation_slug].present? || params[:path_prefix].present?
+    unless params[:organisation_slug].present? || params[:path_prefixes].present?
       head :bad_request
       return
     end
@@ -26,11 +28,15 @@ class AnonymousFeedbackController < ApplicationController
 
   def scope
     AnonymousContact.
-      for_query_parameters(path_prefix: params[:path_prefix],
+      for_query_parameters(path_prefixes: params[:path_prefixes],
                            organisation_slug: params[:organisation_slug],
                            from: dates[0],
                            to: dates[1]).
       most_recent_first
+  end
+
+  def clean_params
+    params[:path_prefixes] = [params[:path_prefix]] if params[:path_prefix].present?
   end
 
   def dates

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -24,6 +24,7 @@ class AnonymousContact < ApplicationRecord
   scope :most_recent_last, -> { order("created_at ASC") }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
   scope :for_organisation_slug, -> (slug) { joins(:organisations).where(organisations: {slug: slug}) }
+  scope :for_document_type, ->(document_type) { joins(:content_item).where(content_items: { document_type: document_type }) }
 
   scope :matching_path_prefixes, ->(paths) do
     if paths.present?
@@ -37,6 +38,7 @@ class AnonymousContact < ApplicationRecord
     from = options[:from] || Date.new(1970)
     to = options[:to] || Date.today
     organisation_slug = options[:organisation_slug]
+    document_type = options[:document_type]
 
     query = only_actionable.
       free_of_personal_info.
@@ -44,6 +46,7 @@ class AnonymousContact < ApplicationRecord
 
     query = query.matching_path_prefixes(path_prefixes) if path_prefixes.present?
     query = query.for_organisation_slug(organisation_slug) if organisation_slug
+    query = query.for_document_type(document_type) if document_type
 
     query
   end

--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -22,12 +22,18 @@ class AnonymousContact < ApplicationRecord
   scope :only_actionable, -> { where(is_actionable: true) }
   scope :most_recent_first, -> { order("created_at DESC") }
   scope :most_recent_last, -> { order("created_at ASC") }
-  scope :matching_path_prefix, ->(path) { where("anonymous_contacts.path LIKE ?", path + "%") if path }
   scope :created_between_days, -> (first_date, last_date) { where(created_at: first_date..last_date.at_end_of_day) }
   scope :for_organisation_slug, -> (slug) { joins(:organisations).where(organisations: {slug: slug}) }
 
+  scope :matching_path_prefixes, ->(paths) do
+    if paths.present?
+      similar_to = paths.map { |p| "#{p}%" }
+      where("anonymous_contacts.path LIKE ANY (ARRAY[?])", similar_to)
+    end
+  end
+
   scope :for_query_parameters, ->(options={}) do
-    path_prefix = options[:path_prefix]
+    path_prefixes = options[:path_prefixes]
     from = options[:from] || Date.new(1970)
     to = options[:to] || Date.today
     organisation_slug = options[:organisation_slug]
@@ -36,7 +42,7 @@ class AnonymousContact < ApplicationRecord
       free_of_personal_info.
       created_between_days(from, to)
 
-    query = query.matching_path_prefix(path_prefix) if path_prefix
+    query = query.matching_path_prefixes(path_prefixes) if path_prefixes.present?
     query = query.for_organisation_slug(organisation_slug) if organisation_slug
 
     query

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -9,13 +9,12 @@ class ContentItem < ApplicationRecord
     where(organisations: { id: organisation.id})
   }
 
-  def self.summary(ordering="last_7_days")
-    midnight_last_night = Date.today.to_time(:utc)
-    ordering_mode = ordering == "path" ? "ASC" : "DESC"
+  scope :for_document_type, ->(document_type) {
+    where(document_type: document_type)
+  }
 
-    last_7_days = sum_column(from: midnight_last_night - 7.days, to: midnight_last_night)
-    last_30_days = sum_column(from: midnight_last_night - 30.days, to: midnight_last_night)
-    last_90_days = sum_column(from: midnight_last_night - 90.days, to: midnight_last_night)
+  def self.summary(ordering="last_7_days")
+    ordering_mode = ordering == "path" ? "ASC" : "DESC"
 
     query = joins(:anonymous_contacts).
       select("content_items.path as path").
@@ -33,12 +32,53 @@ class ContentItem < ApplicationRecord
       map { |row| integers_for_sum_columns(row) }
   end
 
+  def self.doctype_summary(ordering: "last_7_days", document_type: nil)
+    ordering_mode = ordering == "document_type" ? "ASC" : "DESC"
+
+    query = joins(:anonymous_contacts).
+        select("content_items.document_type as document_type").
+        select("#{last_7_days} AS last_7_days").
+        select("#{last_30_days} AS last_30_days").
+        select("#{last_90_days} AS last_90_days").
+        where(document_type: document_type).
+        where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days).
+        group("content_items.document_type").
+        having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0").
+        order("#{ordering} #{ordering_mode}")
+
+    connection.
+        select_all(query).
+        map(&:symbolize_keys).
+        map { |row| integers_for_sum_columns(row) }
+  end
+
   def fetch_organisations
     self.organisations = Organisation.for_path(path)
     save!
   end
 
+  def self.all_document_types
+    self.distinct.pluck(:document_type).reject { |d| d == '' }.compact
+  end
+
+  def self.midnight_last_night
+    Date.today.to_time(:utc)
+  end
+
+  def self.last_7_days
+    sum_column(from: midnight_last_night - 7.days, to: midnight_last_night)
+  end
+
+  def self.last_30_days
+    sum_column(from: midnight_last_night - 30.days, to: midnight_last_night)
+  end
+
+  def self.last_90_days
+    sum_column(from: midnight_last_night - 90.days, to: midnight_last_night)
+  end
+
 private
+
   def self.sum_column(options)
     "SUM(
        CASE WHEN anonymous_contacts.created_at BETWEEN '#{options[:from].to_s(:db)}' AND '#{options[:to].to_s(:db)}' THEN 1

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -22,8 +22,9 @@ class FeedbackExportRequest < ApplicationRecord
     if path_filters
       parts += segments_of_first_path + and_x_number_of_other_paths
     end
-    parts << filters[:organisation_slug] if filters[:organisation_slug]
-    self.filename = "#{parts.join('_')}.csv"
+    parts << filters[:organisation_slug] if filters[:organisation_slug].present?
+    parts << filters[:document_type] if filters[:document_type].present?
+    self.filename = "#{parts.join("_")}.csv"
   end
 
   def path_filters

--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -8,6 +8,7 @@ class FeedbackExportRequest < ApplicationRecord
 
   before_validation on: :create do
     filters[:to] ||= Date.today
+    filters[:path_prefixes] = path_filters
     generate_filename! if filename.nil?
   end
 
@@ -17,9 +18,34 @@ class FeedbackExportRequest < ApplicationRecord
       filters[:from].nil? ? "0000-00-00" : filters[:from].to_date.iso8601,
       filters[:to].nil? ? Date.today.iso8601 : filters[:to].to_date.iso8601,
     ]
-    parts += filters[:path_prefix].split("/").reject(&:blank?) if filters[:path_prefix].present?
-    parts << filters[:organisation_slug] if filters[:organisation_slug].present?
-    self.filename = "#{parts.join("_")}.csv"
+
+    if path_filters
+      parts += segments_of_first_path + and_x_number_of_other_paths
+    end
+    parts << filters[:organisation_slug] if filters[:organisation_slug]
+    self.filename = "#{parts.join('_')}.csv"
+  end
+
+  def path_filters
+    filters[:path_prefixes] = [filters[:path_prefix]] if filters[:path_prefix]
+    filters.delete(:path_prefix)
+    @path_filters ||= filters[:path_prefixes]
+  end
+
+  def segments_of_first_path
+    path_filters.first.split("/").reject(&:blank?)
+  end
+
+  def and_x_number_of_other_paths
+    count = path_filters.count - 1
+    base_path = path_filters.first == '/' ? ['base_path'] : []
+    if count >= 2
+      base_path + ['and', count, 'other', 'paths']
+    elsif count == 1
+      base_path + %w[and another path]
+    else
+      []
+    end
   end
 
   def results

--- a/app/workers/content_item_populate_doctype_worker.rb
+++ b/app/workers/content_item_populate_doctype_worker.rb
@@ -1,0 +1,21 @@
+class ContentItemPopulateDoctypeWorker
+  include Sidekiq::Worker
+
+  def perform
+    content_store = GdsApi::ContentStore.new(Plek.find('content-store'))
+    document_type_not_found = []
+
+    ContentItem.all.each do |content_item|
+      found_content_item = content_store.content_item(content_item.path)
+
+      if found_content_item.present?
+        document_type = looked_up_item["document_type"]
+        content_item.update_attributes(:document_type, document_type)
+      else
+        document_type_not_found << content_item.path
+      end
+    end
+
+    Rails.logger.warn "Document type not found for the following content items: #{document_type_not_found.join(', ')}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,9 @@ Rails.application.routes.draw do
          format: false,
          to: 'problem_reports#mark_reviewed_for_spam'
 
-    get '/organisations/:slug', to: "organisations#show"
+    get '/organisations/:slug', to: 'organisations#show'
+    get '/document-types', to: 'document_types#index', format: false
+    get '/document-types/:document_type', to: 'document_types#show', format: false
   end
 
   resources 'page-improvements',

--- a/db/migrate/20171204124407_add_document_type_to_content_items.rb
+++ b/db/migrate/20171204124407_add_document_type_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddDocumentTypeToContentItems < ActiveRecord::Migration[5.0]
+ def change
+   add_column :content_items, :document_type, :string
+ end
+end

--- a/db/migrate/20171204155340_populate_document_type_for_content_items.rb
+++ b/db/migrate/20171204155340_populate_document_type_for_content_items.rb
@@ -1,0 +1,9 @@
+class PopulateDocumentTypeForContentItems < ActiveRecord::Migration[5.0]
+  def up
+    ContentItemPopulateDoctypeWorker.perform_async
+  end
+
+  def down
+    ContentItem.update_all(document_type: nil)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -131,7 +131,8 @@ CREATE TABLE content_items (
     id integer NOT NULL,
     path character varying(2048) NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    document_type character varying
 );
 
 
@@ -327,14 +328,6 @@ ALTER TABLE ONLY organisations
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
 -- Name: index_anonymous_contacts_on_content_item_id_and_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -416,6 +409,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20151203001139'),
 ('20160511164547'),
 ('20160822145924'),
-('20160826105129');
+('20160826105129'),
+('20171204124407'),
+('20171204155340');
 
 

--- a/lib/content_store_lookup.rb
+++ b/lib/content_store_lookup.rb
@@ -15,6 +15,7 @@ class ContentStoreLookup
     LookedUpContentItem.new(
       path: response['base_path'],
       organisations: organisations_from(response),
+      document_type: response['document_type'] || ''
     ) if response.present?
   end
 

--- a/lib/fix_misreported_done_page_service_feedback.rb
+++ b/lib/fix_misreported_done_page_service_feedback.rb
@@ -26,7 +26,7 @@ private
   attr_reader :logger, :start_date, :end_date
 
   def all_done_page_paths
-    @all_done_page_paths ||= ServiceFeedback.matching_path_prefix('/done').select(:path).distinct.pluck(:path)
+    @all_done_page_paths ||= ServiceFeedback.matching_path_prefixes(['/done']).select(:path).distinct.pluck(:path)
   end
 
   def fetch_misreported_service_feedback(service_slug, for_feedback_type: ServiceFeedback)

--- a/lib/looked_up_content_item.rb
+++ b/lib/looked_up_content_item.rb
@@ -1,9 +1,10 @@
 class LookedUpContentItem
-  attr_accessor :path
+  attr_accessor :path, :document_type
 
-  def initialize(path:, organisations: [])
+  def initialize(path:, organisations: [], document_type: nil)
     @path = path
     @organisations = organisations
+    @document_type = document_type
   end
 
   def organisations

--- a/spec/controllers/anonymous_feedback/document_types_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/document_types_controller_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+RSpec.describe AnonymousFeedback::DocumentTypesController, type: :controller do
+  describe '#index' do
+    context 'with existing content items' do
+      let!(:sa_content_items) { create_list(:content_item, 2, document_type: 'smart_answer') }
+      let!(:cs_content_items) { create_list(:content_item, 3, document_type: 'case_study') }
+      let!(:no_doctype_content_items) { create_list(:content_item, 3, document_type: '') }
+      let!(:nil_doctype_content_items) { create_list(:content_item, 3, document_type: nil) }
+
+      before do
+        get :index
+      end
+
+      subject { response }
+
+      it { is_expected.to be_success }
+
+      it 'returns a result' do
+        expect(JSON.parse(response.body)).to be_eql(%w[case_study smart_answer])
+      end
+
+      it 'filters out nils' do
+        expect(JSON.parse(response.body)).to_not include(nil)
+      end
+
+      it 'filters out blank document types' do
+        expect(JSON.parse(response.body)).to_not include("")
+      end
+    end
+
+    context 'with no content items' do
+      before do
+        get :index
+      end
+
+      subject { response }
+
+      it { is_expected.to be_success }
+
+      it 'returns an empty array' do
+        expect(JSON.parse(response.body)).to be_eql([])
+      end
+    end
+  end
+
+  describe '#show' do
+    let!(:no_doctype_content_items) {
+      create(
+        :content_item,
+        document_type: '',
+        created_at: 2.days.ago,
+        anonymous_contacts: create_list(:anonymous_contact, 2, created_at: 2.days.ago)
+      )
+    }
+    let!(:nil_doctype_content_items) {
+      create(
+        :content_item,
+        document_type: nil,
+        created_at: 2.days.ago,
+        anonymous_contacts: create_list(:anonymous_contact, 3, created_at: 2.days.ago)
+      )
+    }
+    let!(:sa_content_items) {
+      create(
+        :content_item,
+        document_type: 'smart_answer',
+        created_at: 70.days.ago,
+        anonymous_contacts: create_list(:anonymous_contact, 1, created_at: 70.days.ago)
+      )
+    }
+    let!(:cs_content_items) {
+      create(
+        :content_item,
+        document_type: 'case_study',
+        created_at: 32.days.ago,
+        anonymous_contacts: create_list(:anonymous_contact, 4, created_at: 32.days.ago)
+      )
+    }
+
+    context 'with no ordering' do
+      subject { response }
+
+      it 'returns the last_7_days ordered summary for smart_answer' do
+        get :show, params: { document_type: 'smart_answer' }
+
+        expect(JSON.parse(subject.body)).to eq(
+          'document_type' => 'smart_answer',
+          'anonymous_feedback_counts' => [
+            {
+              'path' => '/search',
+              'last_7_days' => 0,
+              'last_30_days' => 0,
+              'last_90_days' => 1
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with a valid ordering' do
+      subject { response }
+
+      it 'returns the ordered summary for the document_type' do
+        get :show, params: { document_type: 'smart_answer', ordering: 'last_30_days' }
+
+        expect(JSON.parse(subject.body)).to eq(
+          'document_type' => 'smart_answer',
+          'anonymous_feedback_counts' => [
+            {
+              'path' => '/search',
+              'last_7_days' => 0,
+              'last_30_days' => 0,
+              'last_90_days' => 1
+            }
+          ]
+        )
+      end
+
+      it 'returns the ordered summary for case_study' do
+        get :show, params: { document_type: 'case_study', ordering: 'last_30_days' }
+
+        expect(JSON.parse(subject.body)).to eq(
+          'document_type' => 'case_study',
+          'anonymous_feedback_counts' => [
+            {
+              'path' => '/search',
+              'last_7_days' => 0,
+              'last_30_days' => 0,
+              'last_90_days' => 4
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with invalid ordering' do
+      before { get :show, params: { document_type: 'smart_answer', ordering: 'foobar' } }
+      subject { response }
+      it { is_expected.to be_success }
+
+      it 'returns the default ordered summary for the organisation' do
+        expect(JSON.parse(subject.body)).to eq(
+          'document_type' => 'smart_answer',
+          'anonymous_feedback_counts' => [
+            {
+              'path' => '/search',
+              'last_7_days' => 0,
+              'last_30_days' => 0,
+              'last_90_days' => 1
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with an invalid document_type' do
+      before { get :show, params: { document_type: 'invalid_document_type' } }
+
+      subject { response }
+
+      it { is_expected.to be_not_found }
+    end
+
+    context 'with an empty document_type' do
+      before { get :show, params: { document_type: '' } }
+
+      subject { response }
+
+      it 'returns the default ordered summary for the organisation' do
+        expect(JSON.parse(subject.body)).to eq(
+          'document_type' => '',
+          'anonymous_feedback_counts' => [
+            {
+              'path' => '/search',
+              'last_7_days' => 2,
+              'last_30_days' => 2,
+              'last_90_days' => 2
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
             from: "2015-05-01",
             to: "2015-06-01",
             path_prefixes: ["/"],
-            notification_email: "foo@example.com"
+            notification_email: "foo@example.com",
+            organisation: "",
+            document_type: ""
           }
         }
       end
@@ -23,14 +25,11 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         expect(FeedbackExportRequest.count).to eq(1)
         feedback_export_request = FeedbackExportRequest.last
 
-        expect(feedback_export_request.filters).to eq(
-          {
-            from: Date.new(2015, 05, 01),
-            to: Date.new(2015, 06, 01),
-            organisation_slug: nil,
-            path_prefixes: ["/"],
-          }
-        )
+        expect(feedback_export_request.filters).to eq(from: Date.new(2015, 0o5, 0o1),
+                                                      to: Date.new(2015, 0o6, 0o1),
+                                                      organisation_slug: "",
+                                                      path_prefixes: ["/"],
+                                                      document_type: "")
       end
     end
 
@@ -41,7 +40,9 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
           export_request: {
             from: "2015-05-01",
             to: "2015-06-01",
-            path_prefixes: ["/"]
+            path_prefixes: ["/"],
+            organisation: "",
+            document_type: ""
           }
         }
       end
@@ -62,6 +63,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
               path_prefix: "/",
               notification_email: "foo@example.com",
               organisation: "",
+              document_type: ""
             }
         }
       end
@@ -74,14 +76,11 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         expect(FeedbackExportRequest.count).to eq(1)
         feedback_export_request = FeedbackExportRequest.last
 
-        expect(feedback_export_request.filters).to eq(
-          {
-            from: Date.new(2015, 0o5, 0o1),
-            to: Date.new(2015, 0o6, 0o1),
-            path_prefixes: ["/"],
-            organisation_slug: "",
-          }
-        )
+        expect(feedback_export_request.filters).to eq(from: Date.new(2015, 0o5, 0o1),
+                                                      to: Date.new(2015, 0o6, 0o1),
+                                                      path_prefixes: ["/"],
+                                                      organisation_slug: "",
+                                                      document_type: "")
       end
     end
   end

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         expect(GenerateFeedbackCsvWorker).to receive(:perform_async).once.with(instance_of(Integer))
         post :create, params: {
           export_request: {
-            from: "2015-05-01", to: "2015-06-01",
-            path_prefixes: ["/"], notification_email: "foo@example.com"
+            from: "2015-05-01",
+            to: "2015-06-01",
+            path_prefixes: ["/"],
+            notification_email: "foo@example.com"
           }
         }
       end
@@ -21,12 +23,14 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         expect(FeedbackExportRequest.count).to eq(1)
         feedback_export_request = FeedbackExportRequest.last
 
-        expect(feedback_export_request.filters).to eq({
-          from: Date.new(2015, 05, 01),
-          to: Date.new(2015, 06, 01),
-          organisation_slug: nil,
-          path_prefixes: ["/"],
-        })
+        expect(feedback_export_request.filters).to eq(
+          {
+            from: Date.new(2015, 05, 01),
+            to: Date.new(2015, 06, 01),
+            organisation_slug: nil,
+            path_prefixes: ["/"],
+          }
+        )
       end
     end
 
@@ -35,7 +39,8 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         expect(GenerateFeedbackCsvWorker).to receive(:perform_async).never
         post :create, params: {
           export_request: {
-            from: "2015-05-01", to: "2015-06-01",
+            from: "2015-05-01",
+            to: "2015-06-01",
             path_prefixes: ["/"]
           }
         }
@@ -56,7 +61,7 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
               to: "2015-06-01",
               path_prefix: "/",
               notification_email: "foo@example.com",
-              organisation: ""
+              organisation: "",
             }
         }
       end
@@ -70,10 +75,12 @@ RSpec.describe AnonymousFeedback::ExportRequestsController, type: :controller do
         feedback_export_request = FeedbackExportRequest.last
 
         expect(feedback_export_request.filters).to eq(
-          from: Date.new(2015, 0o5, 0o1),
-          to: Date.new(2015, 0o6, 0o1),
-          path_prefixes: ["/"],
-          organisation_slug: ""
+          {
+            from: Date.new(2015, 0o5, 0o1),
+            to: Date.new(2015, 0o6, 0o1),
+            path_prefixes: ["/"],
+            organisation_slug: "",
+          }
         )
       end
     end

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -113,7 +113,7 @@ describe AnonymousFeedbackController do
           "total_count" => 0,
           "current_page" => 1,
           "pages" => 0,
-                                     )
+        )
       end
     end
 
@@ -203,10 +203,12 @@ describe AnonymousFeedbackController do
     describe "filter by document type" do
       let(:hmrc) { create(:organisation, slug: 'hm-revenue-customs') }
       let(:smart_answer) {
-        create(:content_item,
-                                  document_type: 'smart_answer',
-                                  path: '/calculate-your-holiday-entitlement',
-                                  organisations: [hmrc])
+        create(
+          :content_item,
+          document_type: 'smart_answer',
+          path: '/calculate-your-holiday-entitlement',
+          organisations: [hmrc]
+        )
       }
       let(:case_study) { create(:content_item, document_type: 'case_study', path: '/government/case-studies/out-of-syria-back-into-school') }
       let!(:sa_problem_report) { create(:problem_report, path: "/xyz", content_item: smart_answer) }

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -75,7 +75,7 @@ FactoryGirl.define do
   end
 
   factory :feedback_export_request do
-    filters Hash.new(path_prefix: "/",
+    filters Hash.new(path_prefixes: "/",
                      from: Date.new(2015,5),
                      to: Date.new(2015,6))
     notification_email "foo@example.com"

--- a/spec/lib/content_item_lookup_spec.rb
+++ b/spec/lib/content_item_lookup_spec.rb
@@ -14,7 +14,7 @@ describe ContentItemLookup do
     {
       content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
       base_path: "/government/organisations/hm-revenue-customs",
-      format: "placeholder_organisation",
+      document_type: "placeholder_organisation",
       title: "HM Revenue & Customs",
     }
   }
@@ -37,21 +37,21 @@ describe ContentItemLookup do
   let(:contact_ukvi_content_store_response) {
     {
       base_path: '/contact-ukvi',
-      format: "placeholder",
+      document_type: "placeholder",
     }
   }
 
   let(:dfid_content_store_response) {
     {
       base_path: '/government/world/organisations/dfid-bangladesh',
-      format: "placeholder",
+      document_type: "placeholder",
     }
   }
 
   let(:hmrc_contact_page_content_store_response) {
     {
       base_path: '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
-      format: "placeholder",
+      document_type: "placeholder",
     }
   }
 
@@ -66,7 +66,7 @@ describe ContentItemLookup do
   let(:case_study_content_store_response) {
     {
       base_path: '/government/case-studies/gender-identity',
-      format: 'case_study',
+      document_type: 'case_study',
       links: {
         lead_organisations: [civil_service_fast_stream_org_response],
       }
@@ -101,6 +101,7 @@ describe ContentItemLookup do
     content_item = subject.lookup('/government/case-studies/gender-identity')
 
     expect(content_item.path).to eq('/government/case-studies/gender-identity')
+    expect(content_item.document_type).to eq('case_study')
     expect(content_item.organisations.first).to match(hash_including(slug: 'civil-service-fast-stream'))
   end
 

--- a/spec/models/anonymous_contact_spec.rb
+++ b/spec/models/anonymous_contact_spec.rb
@@ -82,19 +82,19 @@ describe AnonymousContact, :type => :model do
   end
 
   context "scopes" do
-    describe "matching_path_prefix" do
+    describe "matching_path_prefixes" do
       let!(:a) { contact(path: "/some-calculator/y/abc") }
       let!(:b) { contact(path: "/some-calculator/y/abc/x") }
       let!(:c) { contact(path: "/tax-disc") }
 
-      it "can find urls beginning with the given path" do
-        result = AnonymousContact.matching_path_prefix("/some-calculator")
+      it "can find urls beginning with the given paths" do
+        result = AnonymousContact.matching_path_prefixes(["/some-calculator", "/tax-disc"])
 
-        expect(result).to contain_exactly(a, b)
+        expect(result).to contain_exactly(a, b, c)
       end
 
       it "is a no-op when given a nil path" do
-        result = AnonymousContact.matching_path_prefix(nil)
+        result = AnonymousContact.matching_path_prefixes(nil)
 
         expect(result).to contain_exactly(a, b, c)
       end
@@ -146,11 +146,12 @@ describe AnonymousContact, :type => :model do
       let!(:personal_info) { contact(path: "/gov", details: "foo@example.com") }
       let!(:not_actionable) { contact(path: "/gov", is_actionable: false, reason_why_not_actionable: "spam") }
 
-      subject { described_class.for_query_parameters(path_prefix: path_prefix,
+      subject {
+        described_class.for_query_parameters(path_prefixes: path_prefixes,
                                                      from: from,
                                                      to: to).sort }
 
-      let(:path_prefix) { nil }
+      let(:path_prefixes) { nil }
       let(:from) { nil }
       let(:to)   { nil }
 
@@ -176,7 +177,7 @@ describe AnonymousContact, :type => :model do
       end
 
       context "with a restrictive path prefix" do
-        let(:path_prefix) { "/gov" }
+        let(:path_prefixes) { ["/gov"] }
         it { is_expected.to eq [contact_1] }
       end
     end

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe FeedbackExportRequest, type: :model do
     let(:from) { nil }
     let(:to)   { nil }
     let(:organisation_slug) { nil }
+    let(:document_type) { nil }
+
     let(:instance) do
       described_class.new(
         filters: {
@@ -34,7 +36,8 @@ RSpec.describe FeedbackExportRequest, type: :model do
           path_prefixes: path_prefixes,
           from: from,
           to: to,
-          organisation_slug: organisation_slug
+          organisation_slug: organisation_slug,
+          document_type: document_type
         }
      )
     end
@@ -79,6 +82,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
           it { is_expected.to eq "feedex_0000-00-00_2015-06-01_hm-revenue-customs.csv" }
         end
+
+        context "with a document type" do
+          let(:document_type) { "smart_answer" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_smart_answer.csv" }
+        end
       end
 
       context "with a from date set" do
@@ -106,6 +115,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
           let(:organisation_slug) { "hm-revenue-customs" }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-06-01_hm-revenue-customs.csv" }
+        end
+
+        context "with a document type" do
+          let(:document_type) { "smart_answer" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-06-01_smart_answer.csv" }
         end
       end
 
@@ -136,6 +151,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
           it { is_expected.to eq "feedex_0000-00-00_2015-05-01_hm-revenue-customs.csv" }
         end
+
+        context "with a document type" do
+          let(:document_type) { "smart_answer" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-05-01_smart_answer.csv" }
+        end
       end
 
       context "with both dates set" do
@@ -164,6 +185,12 @@ RSpec.describe FeedbackExportRequest, type: :model do
           let(:organisation_slug) { "hm-revenue-customs" }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01_hm-revenue-customs.csv" }
+        end
+
+        context "with a document type" do
+          let(:document_type) { "smart_answer" }
+
+          it { is_expected.to eq "feedex_2015-04-01_2015-05-01_smart_answer.csv" }
         end
       end
 
@@ -209,7 +236,8 @@ RSpec.describe FeedbackExportRequest, type: :model do
           from: Date.new(2015, 4),
           to: Date.new(2015, 5),
           path_prefixes: ["/"],
-          organisation_slug: "hm-revenue-customs"
+          organisation_slug: "hm-revenue-customs",
+          document_type: "smart_answer"
         }
       ).results
     end
@@ -220,7 +248,8 @@ RSpec.describe FeedbackExportRequest, type: :model do
         from: Date.new(2015, 4),
         to: Date.new(2015, 5),
         path_prefixes: ["/"],
-        organisation_slug: "hm-revenue-customs"
+        organisation_slug: "hm-revenue-customs",
+        document_type: "smart_answer"
       ).and_return(double("scope", most_recent_last: [contact]))
 
       expect(subject).to eq [contact]

--- a/spec/models/feedback_export_request_spec.rb
+++ b/spec/models/feedback_export_request_spec.rb
@@ -22,36 +22,54 @@ RSpec.describe FeedbackExportRequest, type: :model do
   end
 
   describe "#generate_filename!" do
-    let(:instance) do
-      described_class.new(filters: {path_prefix: path_prefix,
-                                    from: from,
-                                    to: to,
-                                    organisation_slug: organisation_slug })
-    end
     let(:path_prefix) { nil }
+    let(:path_prefixes) { nil }
     let(:from) { nil }
     let(:to)   { nil }
     let(:organisation_slug) { nil }
+    let(:instance) do
+      described_class.new(
+        filters: {
+          path_prefix: path_prefix,
+          path_prefixes: path_prefixes,
+          from: from,
+          to: to,
+          organisation_slug: organisation_slug
+        }
+     )
+    end
 
     describe "the resulting filename" do
       before { instance.generate_filename! }
       subject(:filename) { instance.filename }
 
       context "with no dates set" do
+        context "with the old type of `path_prefix` filter" do
+          let(:path_prefix) { "/vat-rates" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_vat-rates.csv" }
+        end
+
+        context "with a root path in the new type of `path_prefixes` filter" do
+          let(:path_prefixes) { ["/vat-rates"] }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_vat-rates.csv" }
+        end
+
         context "with a root path" do
-          let(:path_prefix) { "/" }
+          let(:path_prefixes) { ["/"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-06-01.csv" }
         end
 
         context "with a single-level path" do
-          let(:path_prefix) { "/gov_and_stuff" }
+          let(:path_prefixes) { ["/gov_and_stuff"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff.csv" }
         end
 
         context "with a multi-level path" do
-          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_news-and-features.csv" }
         end
@@ -67,19 +85,19 @@ RSpec.describe FeedbackExportRequest, type: :model do
         let(:from) { Date.new(2015, 4, 1) }
 
         context "with a root path" do
-          let(:path_prefix) { "/" }
+          let(:path_prefixes) { ["/"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-06-01.csv" }
         end
 
         context "with a single-level path" do
-          let(:path_prefix) { "/gov_and_stuff" }
+          let(:path_prefixes) { ["/gov_and_stuff"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-06-01_gov_and_stuff.csv" }
         end
 
         context "with a multi-level path" do
-          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-06-01_gov_and_stuff_news-and-features.csv" }
         end
@@ -95,19 +113,19 @@ RSpec.describe FeedbackExportRequest, type: :model do
         let(:to) { Date.new(2015, 5, 1) }
 
         context "with a root path" do
-          let(:path_prefix) { "/" }
+          let(:path_prefixes) { ["/"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-05-01.csv" }
         end
 
         context "with a single-level path" do
-          let(:path_prefix) { "/gov_and_stuff" }
+          let(:path_prefixes) { ["/gov_and_stuff"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-05-01_gov_and_stuff.csv" }
         end
 
         context "with a multi-level path" do
-          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features"] }
 
           it { is_expected.to eq "feedex_0000-00-00_2015-05-01_gov_and_stuff_news-and-features.csv" }
         end
@@ -125,19 +143,19 @@ RSpec.describe FeedbackExportRequest, type: :model do
         let(:to) { Date.new(2015, 5, 1) }
 
         context "with a root path" do
-          let(:path_prefix) { "/" }
+          let(:path_prefixes) { ["/"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01.csv" }
         end
 
         context "with a single-level path" do
-          let(:path_prefix) { "/gov_and_stuff" }
+          let(:path_prefixes) { ["/gov_and_stuff"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01_gov_and_stuff.csv" }
         end
 
         context "with a multi-level path" do
-          let(:path_prefix) { "/gov_and_stuff/news-and-features" }
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features"] }
 
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01_gov_and_stuff_news-and-features.csv" }
         end
@@ -148,24 +166,62 @@ RSpec.describe FeedbackExportRequest, type: :model do
           it { is_expected.to eq "feedex_2015-04-01_2015-05-01_hm-revenue-customs.csv" }
         end
       end
+
+      context "with multiple paths" do
+        context "with a root path" do
+          let(:path_prefixes) { ["/vat-rates", "/", "/guidance"] }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_vat-rates_and_2_other_paths.csv" }
+        end
+
+        context "with a root path as the first parameter" do
+          let(:path_prefixes) { ["/", "/vat-rates", "/guidance"] }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_base_path_and_2_other_paths.csv" }
+        end
+
+        context "with a single-level path" do
+          let(:path_prefixes) { ["/gov_and_stuff", "/vat-rates", "/guidance"] }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_and_2_other_paths.csv" }
+        end
+
+        context "with a multi-level path" do
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features", "/vat-rates", "/guidance"] }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_news-and-features_and_2_other_paths.csv" }
+        end
+
+        context "with an organisation slug" do
+          let(:path_prefixes) { ["/gov_and_stuff/news-and-features", "/vat-rates", "/guidance"] }
+          let(:organisation_slug) { "hm-revenue-customs" }
+
+          it { is_expected.to eq "feedex_0000-00-00_2015-06-01_gov_and_stuff_news-and-features_and_2_other_paths_hm-revenue-customs.csv" }
+        end
+      end
     end
   end
 
   describe "#results" do
     subject do
-      described_class.new(filters: {from: Date.new(2015, 4),
-                                    to: Date.new(2015, 5),
-                                    path_prefix: "/",
-                                    organisation_slug: "hm-revenue-customs"}).results
+      described_class.new(
+        filters: {
+          from: Date.new(2015, 4),
+          to: Date.new(2015, 5),
+          path_prefixes: ["/"],
+          organisation_slug: "hm-revenue-customs"
+        }
+      ).results
     end
 
     it "uses the scope from the model with the correct parameters" do
       contact = double("AnonymousContact")
-      expect(AnonymousContact).to receive(:for_query_parameters).with(from: Date.new(2015, 4),
-                                                                      to: Date.new(2015, 5),
-                                                                      path_prefix: "/",
-                                                                      organisation_slug: "hm-revenue-customs").
-        and_return(double("scope", most_recent_last: [contact]))
+      expect(AnonymousContact).to receive(:for_query_parameters).with(
+        from: Date.new(2015, 4),
+        to: Date.new(2015, 5),
+        path_prefixes: ["/"],
+        organisation_slug: "hm-revenue-customs"
+      ).and_return(double("scope", most_recent_last: [contact]))
 
       expect(subject).to eq [contact]
     end
@@ -173,10 +229,17 @@ RSpec.describe FeedbackExportRequest, type: :model do
 
   describe "#generate_csv" do
     before do
-      create(:anonymous_contact, path: "/",
-                                 created_at: Time.utc(2015, 6, 1, 10),
-                                 referrer: "http://www.example.com/")
-      create(:anonymous_contact, path: "/gov", created_at: Time.utc(2015, 6, 1, 20))
+      create(
+        :anonymous_contact,
+        path: "/",
+        created_at: Time.utc(2015, 6, 1, 10),
+        referrer: "http://www.example.com/"
+      )
+      create(
+        :anonymous_contact,
+        path: "/gov",
+        created_at: Time.utc(2015, 6, 1, 20)
+      )
     end
 
     let(:io) { StringIO.new }

--- a/spec/requests/anonymous_feedback_feed_spec.rb
+++ b/spec/requests/anonymous_feedback_feed_spec.rb
@@ -41,7 +41,7 @@ describe "Anonymous feedback feed" do
     end
 
     it "returns feedback with the appropriate fields in reverse chronological order" do
-      get_json "/anonymous-feedback?path_prefix=/"
+      get_json "/anonymous-feedback?path_prefixes[]=/"
       expect(response.status).to eq(200)
 
       expect(json_response["results"]).to eq([


### PR DESCRIPTION
Add endpoints for searching for feedback by:
- multiple paths for feedback
- document type 

Also adds migration to populate the `document_type` for content items. 

For: https://trello.com/c/IB9P5EyE/266-introduce-new-browse-options-for-feedex