### PR TITLE
Use ORs for multiple path matching instead of LIKE ANY

### DIFF
--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -29,7 +29,7 @@ class AnonymousContact < ApplicationRecord
   scope :matching_path_prefixes, ->(paths) do
     if paths.present?
       similar_to = paths.map { |p| "#{p}%" }
-      where("anonymous_contacts.path LIKE ANY (ARRAY[?])", similar_to)
+      where(similar_to.map { "anonymous_contacts.path LIKE ?" }.join(' OR '), *similar_to)
     end
   end
 


### PR DESCRIPTION
PostgreSQL isn’t able to use the path index when matching against an
array of patterns. Switching this to generate `OR`ed conditions speeds
this up by using the index again.

Before: https://explain.depesz.com/s/lIIG
After: https://explain.depesz.com/s/tZJ9

This wasn’t too bad for actual queries for data because the `created_at`
index was used as a pre filter. However on `COUNT` queries to determine
total number of responses, a full table scan was needed.