### PR TITLE
Add endpoint to retrieve the count of feedback by day

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ else
   gem 'gds-api-adapters', '~> 51.2'
 end
 
+gem 'kaminari', '1.1.1'
 gem 'whenever', '0.10.0', require: false
 gem 'mlanett-redis-lock', '0.2.7'
 gem "gds_zendesk", '3.0.0'
@@ -30,6 +31,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'database_cleaner', '1.6.2'
   gem 'rspec-rails', '3.5.2'
   gem 'rspec-collection_matchers', '1.1.2'
   gem 'simplecov', '0.15.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
+    database_cleaner (1.6.2)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
@@ -107,6 +108,18 @@ GEM
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
     json (2.1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.1)
     link_header (0.0.8)
     listen (3.1.5)
@@ -311,6 +324,7 @@ PLATFORMS
 DEPENDENCIES
   ci_reporter (= 2.0.0)
   ci_reporter_rspec (= 1.0.0)
+  database_cleaner (= 1.6.2)
   factory_girl_rails (~> 4.7.0)
   fakefs
   gds-api-adapters (~> 51.2)
@@ -318,6 +332,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 1.3.0)
   govuk_sidekiq (~> 2.0)
+  kaminari (= 1.1.1)
   listen (~> 3.1.5)
   mlanett-redis-lock (= 0.2.7)
   pg (~> 0.21.0)

--- a/app/controllers/feedback_by_day_controller.rb
+++ b/app/controllers/feedback_by_day_controller.rb
@@ -1,15 +1,24 @@
 require 'date_parser'
 
 class FeedbackByDayController < ApplicationController
+  before_action :validate_params!, only: :index
+
   def index
-    unless date
-      head :bad_request
-      return
-    end
-    render json: {results: FeedbackByDay.retrieve(date)}
+    render json: FeedbackByDay.retrieve(date, params[:page], params[:per_page])
   end
 
 private
+
+  def validate_params!
+    head :bad_request unless valid_params?
+  end
+
+  def valid_params?
+    return false if params[:page] && !params[:page].match(/^\d+$/)
+    return false if params[:per_page] && !params[:per_page].match(/^\d+$/)
+    date
+  end
+
   def date
     DateParser.parse(params[:date])
   end

--- a/app/controllers/feedback_by_day_controller.rb
+++ b/app/controllers/feedback_by_day_controller.rb
@@ -1,0 +1,16 @@
+require 'date_parser'
+
+class FeedbackByDayController < ApplicationController
+  def index
+    unless date
+      head :bad_request
+      return
+    end
+    render json: {results: FeedbackByDay.retrieve(date)}
+  end
+
+private
+  def date
+    DateParser.parse(params[:date])
+  end
+end

--- a/app/models/feedback_by_day.rb
+++ b/app/models/feedback_by_day.rb
@@ -1,0 +1,22 @@
+class FeedbackByDay
+  attr_reader :date
+  def self.retrieve(date)
+    new(date).retrieve
+  end
+
+  def initialize(date)
+    @date = date
+  end
+
+  def retrieve
+    AnonymousContact.where(created_at: get_range)
+      .group(:path).order(:path).count(:id).map do |k, v|
+      {path: k, count: v}
+    end
+  end
+
+private
+  def get_range
+    date.beginning_of_day..date.end_of_day
+  end
+end

--- a/app/models/feedback_by_day.rb
+++ b/app/models/feedback_by_day.rb
@@ -1,21 +1,36 @@
 class FeedbackByDay
-  attr_reader :date
-  def self.retrieve(date)
-    new(date).retrieve
+  attr_reader :date, :current_page, :per_page
+  def self.retrieve(date, page, per_page)
+    new(date, page, per_page).retrieve
   end
 
-  def initialize(date)
+  def initialize(date, page, per_page)
     @date = date
+    @current_page = page || 1
+    @per_page = per_page || 100
   end
 
   def retrieve
-    AnonymousContact.where(created_at: get_range)
-      .group(:path).order(:path).count(:id).map do |k, v|
-      {path: k, count: v}
+    results = summary_query.count(:id).map do |k, v|
+      { path: k, count: v }
     end
+    {
+      results: results,
+      total_count: summary_query.total_count,
+      current_page: summary_query.current_page,
+      pages: summary_query.total_pages,
+      page_size: summary_query.limit_value
+    }
   end
 
 private
+
+  def summary_query
+    AnonymousContact.where(created_at: get_range)
+      .group(:path).page(current_page).per(per_page)
+      .order(:path)
+  end
+
   def get_range
     date.beginning_of_day..date.end_of_day
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,5 +62,7 @@ Rails.application.routes.draw do
             format: false,
             param: :slug
 
+  get '/feedback-by-day/:date', to: 'feedback_by_day#index', format: false
+
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }
 end

--- a/spec/models/feedback_by_day_spec.rb
+++ b/spec/models/feedback_by_day_spec.rb
@@ -3,30 +3,101 @@ require 'feedback_by_day'
 
 describe FeedbackByDay do
   before :each do
-    create_list(:problem_report, 5, path: '/browse/abroad', created_at: Time.utc(2018, 02, 1, 0, 1, 0))
-    create_list(:problem_report, 4, path: '/browse/abroad', created_at: Time.utc(2018, 02, 2))
-    create_list(:problem_report, 6, path: '/browse/benefits', created_at: Time.utc(2018, 02, 1, 23, 59, 59))
-    create_list(:problem_report, 2, path: '/browse/benefits', created_at: Time.utc(2018, 02, 2))
-    create_list(:problem_report, 8, path: '/browse/tax', created_at: Time.utc(2018, 02, 1))
-    create_list(:problem_report, 3, path: '/browse/tax', created_at: Time.utc(2018, 02, 2))
+    create_list(:problem_report, 5, path: '/browse/abroad', created_at: Time.utc(2018, 2, 1, 0, 1, 0))
+    create_list(:problem_report, 4, path: '/browse/abroad', created_at: Time.utc(2018, 2, 2))
+    create_list(:problem_report, 6, path: '/browse/benefits', created_at: Time.utc(2018, 2, 1, 23, 59, 59))
+    create_list(:problem_report, 2, path: '/browse/benefits', created_at: Time.utc(2018, 2, 2))
+    create_list(:problem_report, 8, path: '/browse/tax', created_at: Time.utc(2018, 2, 1))
+    create_list(:problem_report, 3, path: '/browse/tax', created_at: Time.utc(2018, 2, 2))
   end
 
-  it "returns the correct data for 1st Feb" do
-    expected = [
-      {path: '/browse/abroad', count: 5},
-      {path: '/browse/benefits', count:6},
-      {path: '/browse/tax', count: 8}
-    ]
-    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1))).to eq expected
+  it 'returns the correct data for 1st Feb' do
+    expected = {
+      results: [
+        { path: '/browse/abroad', count: 5 },
+        { path: '/browse/benefits', count: 6 },
+        { path: '/browse/tax', count: 8 }
+      ],
+      total_count: 3,
+      current_page: 1,
+      pages: 1,
+      page_size: 100
+    }
+    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1), nil, nil)).to eq expected
   end
 
-  it "returns the correct data for 2nd Feb" do
-    expected = [
-      {path: '/browse/abroad', count: 5},
-      {path: '/browse/benefits', count:6},
-      {path: '/browse/tax', count: 8}
-    ]
-    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1))).to eq expected
+  it 'returns the correct data for 2nd Feb' do
+    expected = {
+      results: [
+        { path: '/browse/abroad', count: 5 },
+        { path: '/browse/benefits', count: 6 },
+        { path: '/browse/tax', count: 8 }
+      ],
+      total_count: 3,
+      current_page: 1,
+      pages: 1,
+      page_size: 100
+    }
+    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1), nil, nil)).to eq expected
   end
 
+  context 'with pagination' do
+    before :each do
+      (1..153).each do |n|
+        create(:problem_report, path: "/aaa/#{pad_number(n)}", created_at: Time.utc(2018, 2, 3))
+      end
+    end
+
+    it 'returns the correct data for the 1st page with default page size of 100' do
+      expected = {
+        results: (1..100).map { |n| create_entry n },
+        total_count: 153,
+        current_page: 1,
+        pages: 2,
+        page_size: 100
+      }
+      expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 3), nil, nil)).to eq expected
+    end
+
+    it 'returns the correct data for the 2nd page with default page size of 100' do
+      expected = {
+        results: (101..153).map { |n| create_entry n },
+        total_count: 153,
+        current_page: 2,
+        pages: 2,
+        page_size: 100
+      }
+      expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 3), 2, nil)).to eq expected
+    end
+
+    it 'returns the correct data with a for the 1st page with specified page size of 50' do
+      expected = {
+        results: (1..50).map { |n| create_entry n },
+        total_count: 153,
+        current_page: 1,
+        pages: 4,
+        page_size: 50
+      }
+      expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 3), 1, 50)).to eq expected
+    end
+
+    it 'returns the correct data with a for the last page with specified page size of 50' do
+      expected = {
+        results: (151..153).map { |n| create_entry n },
+        total_count: 153,
+        current_page: 4,
+        pages: 4,
+        page_size: 50
+      }
+      expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 3), 4, 50)).to eq expected
+    end
+  end
+
+  def create_entry(n)
+    { path: "/aaa/#{pad_number(n)}", count: 1 }
+  end
+
+  def pad_number(n)
+    n.to_s.rjust(3, '0')
+  end
 end

--- a/spec/models/feedback_by_day_spec.rb
+++ b/spec/models/feedback_by_day_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'feedback_by_day'
+
+describe FeedbackByDay do
+  before :each do
+    create_list(:problem_report, 5, path: '/browse/abroad', created_at: Time.utc(2018, 02, 1, 0, 1, 0))
+    create_list(:problem_report, 4, path: '/browse/abroad', created_at: Time.utc(2018, 02, 2))
+    create_list(:problem_report, 6, path: '/browse/benefits', created_at: Time.utc(2018, 02, 1, 23, 59, 59))
+    create_list(:problem_report, 2, path: '/browse/benefits', created_at: Time.utc(2018, 02, 2))
+    create_list(:problem_report, 8, path: '/browse/tax', created_at: Time.utc(2018, 02, 1))
+    create_list(:problem_report, 3, path: '/browse/tax', created_at: Time.utc(2018, 02, 2))
+  end
+
+  it "returns the correct data for 1st Feb" do
+    expected = [
+      {path: '/browse/abroad', count: 5},
+      {path: '/browse/benefits', count:6},
+      {path: '/browse/tax', count: 8}
+    ]
+    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1))).to eq expected
+  end
+
+  it "returns the correct data for 2nd Feb" do
+    expected = [
+      {path: '/browse/abroad', count: 5},
+      {path: '/browse/benefits', count:6},
+      {path: '/browse/tax', count: 8}
+    ]
+    expect(FeedbackByDay.retrieve(Time.utc(2018, 2, 1))).to eq expected
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,5 +44,18 @@ RSpec.configure do |config|
   RSpec.configure do |config|
     config.include(Shoulda::Matchers::ActiveModel, type: :model)
     config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+
+    config.before(:suite) do
+      DatabaseCleaner.clean_with(:truncation)
+    end
+
+    config.before(:each) do
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.start
+    end
+
+    config.after(:each) do
+      DatabaseCleaner.clean
+    end
   end
 end

--- a/spec/requests/feedback_by_day_spec.rb
+++ b/spec/requests/feedback_by_day_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 describe "/feedback-by-day endpoint" do
   before :each do
-    create_list(:problem_report, 5, path: "/browse/abroad", created_at: Time.utc(2018, 02, 21))
-    create_list(:problem_report, 4, path: "/browse/abroad", created_at: Time.utc(2018, 02, 22))
-    create_list(:problem_report, 6, path: "/browse/benefits", created_at: Time.utc(2018, 02, 21))
-    create_list(:problem_report, 2, path: "/browse/benefits", created_at: Time.utc(2018, 02, 22))
-    create_list(:problem_report, 8, path: "/browse/tax", created_at: Time.utc(2018, 02, 21))
-    create_list(:problem_report, 3, path: "/browse/tax", created_at: Time.utc(2018, 02, 22))
+    create_list(:problem_report, 5, path: "/browse/abroad", created_at: Time.utc(2018, 0o2, 21))
+    create_list(:problem_report, 4, path: "/browse/abroad", created_at: Time.utc(2018, 0o2, 22))
+    create_list(:problem_report, 6, path: "/browse/benefits", created_at: Time.utc(2018, 0o2, 21))
+    create_list(:problem_report, 2, path: "/browse/benefits", created_at: Time.utc(2018, 0o2, 22))
+    create_list(:problem_report, 8, path: "/browse/tax", created_at: Time.utc(2018, 0o2, 21))
+    create_list(:problem_report, 3, path: "/browse/tax", created_at: Time.utc(2018, 0o2, 22))
   end
 
   context 'with invalid requests' do
@@ -18,6 +18,16 @@ describe "/feedback-by-day endpoint" do
 
     it 'returns bad request for invalid date' do
       get_json "/feedback-by-day/2018-02-31"
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns bad request for invalid page' do
+      get_json "/feedback-by-day/2018-02-02?page=blah"
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns bad request for invalid per_page' do
+      get_json "/feedback-by-day/2018-02-02?per_page=blah"
       expect(response.status).to eq(400)
     end
   end
@@ -40,6 +50,12 @@ describe "/feedback-by-day endpoint" do
           'count' => 8
         }
       ])
+      expect(json_response).to include(
+        'total_count' => 3,
+        'current_page' => 1,
+        'pages' => 1,
+        'page_size' => 100
+      )
     end
 
     it 'returns the correct figures for 2018-02-22' do
@@ -59,6 +75,52 @@ describe "/feedback-by-day endpoint" do
           'count' => 3
         }
       ])
+      expect(json_response).to include(
+        'total_count' => 3,
+        'current_page' => 1,
+        'pages' => 1,
+        'page_size' => 100
+      )
+    end
+  end
+
+  context 'with pagination' do
+    it 'returns the correct figures for 2018-02-21 1st page' do
+      get_json "/feedback-by-day/2018-02-21?page=1&per_page=2"
+      expect(response.status).to eq(200)
+      expect(json_response["results"]).to eq([
+        {
+          'path' => '/browse/abroad',
+          'count' => 5,
+        },
+        {
+          'path' => '/browse/benefits',
+          'count' => 6,
+        }
+      ])
+      expect(json_response).to include(
+        'total_count' => 3,
+        'current_page' => 1,
+        'pages' => 2,
+        'page_size' => 2
+      )
+    end
+
+    it 'returns the correct figures for 2018-02-21 2nd page' do
+      get_json "/feedback-by-day/2018-02-21?page=2&per_page=2"
+      expect(response.status).to eq(200)
+      expect(json_response["results"]).to eq([
+        {
+          'path' => '/browse/tax',
+          'count' => 8
+        }
+      ])
+      expect(json_response).to include(
+        'total_count' => 3,
+        'current_page' => 2,
+        'pages' => 2,
+        'page_size' => 2
+      )
     end
   end
 end

--- a/spec/requests/feedback_by_day_spec.rb
+++ b/spec/requests/feedback_by_day_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe "/feedback-by-day endpoint" do
+  before :each do
+    create_list(:problem_report, 5, path: "/browse/abroad", created_at: Time.utc(2018, 02, 21))
+    create_list(:problem_report, 4, path: "/browse/abroad", created_at: Time.utc(2018, 02, 22))
+    create_list(:problem_report, 6, path: "/browse/benefits", created_at: Time.utc(2018, 02, 21))
+    create_list(:problem_report, 2, path: "/browse/benefits", created_at: Time.utc(2018, 02, 22))
+    create_list(:problem_report, 8, path: "/browse/tax", created_at: Time.utc(2018, 02, 21))
+    create_list(:problem_report, 3, path: "/browse/tax", created_at: Time.utc(2018, 02, 22))
+  end
+
+  context 'with invalid requests' do
+    it 'returns bad request for non date' do
+      get_json "/feedback-by-day/blah"
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns bad request for invalid date' do
+      get_json "/feedback-by-day/2018-02-31"
+      expect(response.status).to eq(400)
+    end
+  end
+
+  context 'with a valid request' do
+    it 'returns the correct figures for 2018-02-21' do
+      get_json "/feedback-by-day/2018-02-21"
+      expect(response.status).to eq(200)
+      expect(json_response["results"]).to eq([
+        {
+          'path' => '/browse/abroad',
+          'count' => 5,
+        },
+        {
+          'path' => '/browse/benefits',
+          'count' => 6,
+        },
+        {
+          'path' => '/browse/tax',
+          'count' => 8
+        }
+      ])
+    end
+
+    it 'returns the correct figures for 2018-02-22' do
+      get_json "/feedback-by-day/2018-02-22"
+      expect(response.status).to eq(200)
+      expect(json_response["results"]).to eq([
+        {
+          'path' => '/browse/abroad',
+          'count' => 4,
+        },
+        {
+          'path' => '/browse/benefits',
+          'count' => 2,
+        },
+        {
+          'path' => '/browse/tax',
+          'count' => 3
+        }
+      ])
+    end
+  end
+end


### PR DESCRIPTION
content-performance-manager needs to retrieve metrics on the number of comment for each content item by day in order to populate it's data warehouse.

This PR implements a new endpoint /feedback-by-day that exposes this information.

the Trello card is [Expose Feedex numbers via Support API](https://trello.com/c/6nz6zXEE/113-5-expose-feedex-numbers-via-support-api)