### PR TITLE
Speed up ContentItem summary queries

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -13,18 +13,18 @@ class ContentItem < ApplicationRecord
     where(document_type: document_type)
   }
 
-  def self.summary(ordering="last_7_days")
+  def self.summary(ordering = "last_7_days")
     ordering_mode = ordering == "path" ? "ASC" : "DESC"
 
-    query = joins(:anonymous_contacts).
-      select("content_items.path as path").
-      select("#{last_7_days} AS last_7_days").
-      select("#{last_30_days} AS last_30_days").
-      select("#{last_90_days} AS last_90_days").
-      where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days).
-      group("content_items.path").
-      having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0").
-      order("#{ordering} #{ordering_mode}")
+    query = joins(:anonymous_contacts)
+      .select("content_items.path AS path")
+      .select("#{last_7_days} AS last_7_days")
+      .select("#{last_30_days} AS last_30_days")
+      .select("#{last_90_days} AS last_90_days")
+      .where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days)
+      .group("content_items.path")
+      .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
+      .order("#{ordering} #{ordering_mode}")
 
     connection.
       select_all(query).
@@ -35,16 +35,16 @@ class ContentItem < ApplicationRecord
   def self.doctype_summary(ordering: "last_7_days", document_type: nil)
     ordering_mode = ordering == "document_type" ? "ASC" : "DESC"
 
-    query = joins(:anonymous_contacts).
-        select("content_items.document_type as document_type").
-        select("#{last_7_days} AS last_7_days").
-        select("#{last_30_days} AS last_30_days").
-        select("#{last_90_days} AS last_90_days").
-        where(document_type: document_type).
-        where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days).
-        group("content_items.document_type").
-        having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0").
-        order("#{ordering} #{ordering_mode}")
+    query = joins(:anonymous_contacts)
+        .select("content_items.document_type as document_type")
+        .select("#{last_7_days} AS last_7_days")
+        .select("#{last_30_days} AS last_30_days")
+        .select("#{last_90_days} AS last_90_days")
+        .where(document_type: document_type)
+        .where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days)
+        .group("content_items.document_type")
+        .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
+        .order("#{ordering} #{ordering_mode}")
 
     connection.
         select_all(query).

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -26,10 +26,7 @@ class ContentItem < ApplicationRecord
       .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
       .order("#{ordering} #{ordering_mode}")
 
-    connection.
-      select_all(query).
-      map(&:symbolize_keys).
-      map { |row| integers_for_sum_columns(row) }
+    connection.select_all(query).map(&:symbolize_keys)
   end
 
   def self.doctype_summary(ordering: "last_7_days", document_type: nil)
@@ -46,10 +43,7 @@ class ContentItem < ApplicationRecord
         .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
         .order("#{ordering} #{ordering_mode}")
 
-    connection.
-        select_all(query).
-        map(&:symbolize_keys).
-        map { |row| integers_for_sum_columns(row) }
+    connection.select_all(query).map(&:symbolize_keys)
   end
 
   def fetch_organisations
@@ -81,11 +75,5 @@ private
 
   def self.sum_column(options)
     "SUM((anonymous_contacts.created_at BETWEEN '#{options[:from].to_s(:db)}' AND '#{options[:to].to_s(:db)}')::INT)"
-  end
-
-  def self.integers_for_sum_columns(row)
-    # the pg ActiveRecord adapter returns strings, even for SUM columns
-    # see http://stackoverflow.com/questions/12571215/connection-select-value-only-returns-strings-in-postgres-with-pg-gem
-    Hash[row.map {|key,value| [key, (key == :path ? value : value.to_i)] }]
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -23,7 +23,7 @@ class ContentItem < ApplicationRecord
       .select("#{last_90_days} AS last_90_days")
       .where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days)
       .group("content_items.path")
-      .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
+      .having("#{last_7_days} > 0 OR #{last_30_days} > 0 OR #{last_90_days} > 0")
       .order("#{ordering} #{ordering_mode}")
 
     connection.select_all(query).map(&:symbolize_keys)
@@ -40,7 +40,7 @@ class ContentItem < ApplicationRecord
         .where(document_type: document_type)
         .where("anonymous_contacts.created_at > ?", midnight_last_night - 90.days)
         .group("content_items.document_type")
-        .having("#{last_7_days} + #{last_30_days} + #{last_90_days} > 0")
+        .having("#{last_7_days} > 0 OR #{last_30_days} > 0 OR #{last_90_days} > 0")
         .order("#{ordering} #{ordering_mode}")
 
     connection.select_all(query).map(&:symbolize_keys)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -80,11 +80,7 @@ class ContentItem < ApplicationRecord
 private
 
   def self.sum_column(options)
-    "SUM(
-       CASE WHEN anonymous_contacts.created_at BETWEEN '#{options[:from].to_s(:db)}' AND '#{options[:to].to_s(:db)}' THEN 1
-            ELSE 0
-            END
-        )"
+    "SUM((anonymous_contacts.created_at BETWEEN '#{options[:from].to_s(:db)}' AND '#{options[:to].to_s(:db)}')::INT)"
   end
 
   def self.integers_for_sum_columns(row)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,46 +3,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "32bbd27bad73bdeb8e675465a21bee81baf307e60d88f8891c07e07ac275835e",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/content_item.rb",
-      "line": 46,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "joins(:anonymous_contacts).select(\"content_items.document_type as document_type\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(:document_type => document_type).where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.document_type\").having(\"#{last_7_days} + #{last_30_days} + #{last_90_days} > 0\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ContentItem",
-        "method": "ContentItem.doctype_summary"
-      },
-      "user_input": "last_7_days",
-      "confidence": "Weak",
-      "note": "This is not a SQL injection because no user input is used at any point."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "50a1fe3ebb68804a2c1d59893525cc100c553f636bc6fae5e5f738fcbfd02dc8",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/content_item.rb",
-      "line": 26,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "joins(:anonymous_contacts).select(\"content_items.path AS path\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.path\").having(\"#{last_7_days} + #{last_30_days} + #{last_90_days} > 0\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ContentItem",
-        "method": "ContentItem.summary"
-      },
-      "user_input": "last_7_days",
-      "confidence": "Weak",
-      "note": "This is not a SQL injection because no user input is used at any point."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "57f01479b7b44a00c607fc8beefdb37f7a7582fc31865e1d76caf9623d037e23",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -59,8 +19,48 @@
       "user_input": "Rails.env",
       "confidence": "Weak",
       "note": "This is not a SQL injection because no user input is used at any point."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "7b165725021184fddd47bbf499b7da4f91a2472e4a4248bb543f9646a8d5ea35",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/content_item.rb",
+      "line": 26,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "joins(:anonymous_contacts).select(\"content_items.path AS path\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.path\").having(\"#{last_7_days} > 0 OR #{last_30_days} > 0 OR #{last_90_days} > 0\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ContentItem",
+        "method": "ContentItem.summary"
+      },
+      "user_input": "last_7_days",
+      "confidence": "Weak",
+      "note": "No user data."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "8bb3980c595356ae94bed406824f9f17e0ac3728c0ce7998d68321c3df73b868",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/content_item.rb",
+      "line": 43,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "joins(:anonymous_contacts).select(\"content_items.document_type as document_type\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(:document_type => document_type).where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.document_type\").having(\"#{last_7_days} > 0 OR #{last_30_days} > 0 OR #{last_90_days} > 0\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ContentItem",
+        "method": "ContentItem.doctype_summary"
+      },
+      "user_input": "last_7_days",
+      "confidence": "Weak",
+      "note": "No user data."
     }
   ],
-  "updated": "2018-09-07 10:32:31 +0100",
+  "updated": "2018-09-07 11:02:42 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -23,6 +23,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "50a1fe3ebb68804a2c1d59893525cc100c553f636bc6fae5e5f738fcbfd02dc8",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/content_item.rb",
+      "line": 26,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "joins(:anonymous_contacts).select(\"content_items.path AS path\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.path\").having(\"#{last_7_days} + #{last_30_days} + #{last_90_days} > 0\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ContentItem",
+        "method": "ContentItem.summary"
+      },
+      "user_input": "last_7_days",
+      "confidence": "Weak",
+      "note": "This is not a SQL injection because no user input is used at any point."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "57f01479b7b44a00c607fc8beefdb37f7a7582fc31865e1d76caf9623d037e23",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -39,28 +59,8 @@
       "user_input": "Rails.env",
       "confidence": "Weak",
       "note": "This is not a SQL injection because no user input is used at any point."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "8562d9a3dedbcb44c567a66f1843b63b5ce0a4b86c42720bac3dac9d82251ba8",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/content_item.rb",
-      "line": 26,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "joins(:anonymous_contacts).select(\"content_items.path as path\").select(\"#{last_7_days} AS last_7_days\").select(\"#{last_30_days} AS last_30_days\").select(\"#{last_90_days} AS last_90_days\").where(\"anonymous_contacts.created_at > ?\", (midnight_last_night - 90.days)).group(\"content_items.path\").having(\"#{last_7_days} + #{last_30_days} + #{last_90_days} > 0\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ContentItem",
-        "method": "ContentItem.summary"
-      },
-      "user_input": "last_7_days",
-      "confidence": "Weak",
-      "note": "This is not a SQL injection because no user input is used at any point."
     }
   ],
-  "updated": "2018-08-02 15:38:00 +0100",
+  "updated": "2018-09-07 10:32:31 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/spec/factories/anonymous_feedback.rb
+++ b/spec/factories/anonymous_feedback.rb
@@ -1,26 +1,26 @@
 FactoryBot.define do
   factory :anonymous_contact, class: AnonymousContact do
-    javascript_enabled true
-    path "/vat-rates"
-    user_agent "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0;)"
-    referrer "http://www.example.com/foo"
+    javascript_enabled { true }
+    path { "/vat-rates" }
+    user_agent { "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0;)" }
+    referrer { "http://www.example.com/foo" }
 
     factory :problem_report, class: ProblemReport
 
     factory :service_feedback, class: ServiceFeedback do
       path { "/done/#{slug}" }
-      slug "apply-carers-allowance"
-      service_satisfaction_rating 5
+      slug { "apply-carers-allowance" }
+      service_satisfaction_rating { 5 }
 
       factory :duplicate_service_feedback, class: ServiceFeedback do
-        is_actionable false
-        reason_why_not_actionable "duplicate"
+        is_actionable { false }
+        reason_why_not_actionable { "duplicate" }
       end
     end
 
     factory :aggregated_service_feedback, class: AggregatedServiceFeedback do
       path { "/done/#{slug}" }
-      slug "apply-carers-allowance"
+      slug { "apply-carers-allowance" }
     end
 
     factory :long_form_contact, class: LongFormContact
@@ -29,55 +29,53 @@ FactoryBot.define do
   factory :organisation do
     slug { title.parameterize }
     web_url { "https://www.gov.uk/government/organisations/#{slug}" }
-    title "Ministry of Magic"
+    title { "Ministry of Magic" }
     acronym { title.split.map { |s| s[0] }.join.upcase }
-    govuk_status "live"
+    govuk_status { "live" }
     sequence(:content_id) { |n| "content_id_#{n}" }
 
     factory :gds do
-      content_id "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-      slug "government-digital-service"
-      web_url "https://www.gov.uk/government/organisations/government-digital-service"
-      title "Government Digital Service"
+      content_id { "af07d5a5-df63-4ddc-9383-6a666845ebe9" }
+      slug { "government-digital-service" }
+      web_url { "https://www.gov.uk/government/organisations/government-digital-service" }
+      title { "Government Digital Service" }
     end
 
     factory :dfid do
-      content_id "db994552-7644-404d-a770-a2fe659c661f"
-      slug "department-for-international-development"
-      web_url "https://www.gov.uk/government/organisations/department-for-international-development"
-      title "Department for International Development"
+      content_id { "db994552-7644-404d-a770-a2fe659c661f" }
+      slug { "department-for-international-development" }
+      web_url { "https://www.gov.uk/government/organisations/department-for-international-development" }
+      title { "Department for International Development" }
     end
 
     factory :ukti do
-      content_id "b045c8df-d3c4-4219-88d8-264dc9ee5cc8"
-      slug "uk-trade-investment"
-      web_url "https://www.gov.uk/government/organisations/uk-trade-investment"
-      title "UK Trade & Investment"
+      content_id { "b045c8df-d3c4-4219-88d8-264dc9ee5cc8" }
+      slug { "uk-trade-investment" }
+      web_url { "https://www.gov.uk/government/organisations/uk-trade-investment" }
+      title { "UK Trade & Investment" }
     end
 
     factory :fco do
-      content_id "9adfc4ed-9f6c-4976-a6d8-18d34356367c"
-      slug "foreign-commonwealth-office"
-      web_url "https://www.gov.uk/government/organisations/foreign-commonwealth-office"
-      title "Foreign & Commonwealth Office"
+      content_id { "9adfc4ed-9f6c-4976-a6d8-18d34356367c" }
+      slug { "foreign-commonwealth-office" }
+      web_url { "https://www.gov.uk/government/organisations/foreign-commonwealth-office" }
+      title { "Foreign & Commonwealth Office" }
     end
 
     factory :hmrc do
-      content_id "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
-      slug "hm-revenue-customs"
-      web_url "https://www.gov.uk/government/organisations/hm-revenue-customs"
-      title "HM Revenue & Customs"
+      content_id { "6667cce2-e809-4e21-ae09-cb0bdc1ddda3" }
+      slug { "hm-revenue-customs" }
+      web_url { "https://www.gov.uk/government/organisations/hm-revenue-customs" }
+      title { "HM Revenue & Customs" }
     end
   end
 
   factory :content_item do
-    path "/search"
+    path { "/search" }
   end
 
   factory :feedback_export_request do
-    filters Hash.new(path_prefixes: "/",
-                     from: Date.new(2015,5),
-                     to: Date.new(2015,6))
-    notification_email "foo@example.com"
+    filters { Hash.new(path_prefixes: "/", from: Date.new(2015, 5), to: Date.new(2015, 6)) }
+    notification_email { "foo@example.com" }
   end
 end


### PR DESCRIPTION
This PR includes a few small changes to the `summary` and `doctype_summary` methods on `ContentItem`s to introduce some performance enhancements.

[Trello Card](https://trello.com/c/VztlS695/447-investigate-options-for-reducing-load-on-the-production-postgres-primary)