### PR TITLE
Make sure URLs to support in emails are external

### DIFF
--- a/app/models/feedback_export_request.rb
+++ b/app/models/feedback_export_request.rb
@@ -65,6 +65,6 @@ class FeedbackExportRequest < ApplicationRecord
   end
 
   def url
-    Plek.find('support') + "/anonymous_feedback/export_requests/#{id}"
+    Plek.find('support', external: true) + "/anonymous_feedback/export_requests/#{id}"
   end
 end


### PR DESCRIPTION
This means that people who receive the emails and don't have access to the `govuk.digital` domain can still view the links.

[Trello Card](https://trello.com/c/25iiQBNZ/572-fix-urls-used-in-emails-sent-by-backend-apps-specifically-support-support-api-probably-others)