### PR TITLE
Add endpoint to capture business finder feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'govuk_app_config', '~> 1.11.2'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 57.2'
+  gem 'gds-api-adapters', '~> 57.3.1'
 end
 
 gem 'kaminari', '1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    gds-api-adapters (57.2.3)
+    gds-api-adapters (57.3.1)
       addressable
       link_header
       null_logger
@@ -385,7 +385,7 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   factory_bot_rails (~> 4.11.1)
   fog-aws (~> 3.3)
-  gds-api-adapters (~> 57.2)
+  gds-api-adapters (~> 57.3.1)
   gds-sso (~> 14.0.0)
   gds_zendesk (= 3.0.0)
   govuk-lint

--- a/app/controllers/anonymous_feedback/content_improvement_controller.rb
+++ b/app/controllers/anonymous_feedback/content_improvement_controller.rb
@@ -1,0 +1,19 @@
+module AnonymousFeedback
+  class ContentImprovementController < ApplicationController
+    def create
+      feedback = ContentImprovementFeedback.new(feedback_params)
+      if feedback.valid?
+        ContentImprovementFeedbackWorker.perform_async(feedback_params)
+        head :accepted
+      else
+        render json: { "errors" => feedback.errors.to_a }, status: 422
+      end
+    end
+
+  private
+
+    def feedback_params
+      params.permit(:description).to_hash
+    end
+  end
+end

--- a/app/models/content_improvement_feedback.rb
+++ b/app/models/content_improvement_feedback.rb
@@ -1,0 +1,17 @@
+require 'field_which_may_contain_personal_information'
+
+class ContentImprovementFeedback < ApplicationRecord
+  before_save :detect_personal_information
+  validates_length_of :description, within: 1..65536
+  validates_inclusion_of :personal_information_status, in: %w[suspected absent], allow_nil: true
+
+private
+
+  def detect_personal_information
+    self.personal_information_status = personal_info_present? ? "suspected" : "absent"
+  end
+
+  def personal_info_present?
+    FieldWhichMayContainPersonalInformation.new(description).include_personal_info?
+  end
+end

--- a/app/workers/content_improvement_feedback_worker.rb
+++ b/app/workers/content_improvement_feedback_worker.rb
@@ -1,0 +1,7 @@
+class ContentImprovementFeedbackWorker
+  include Sidekiq::Worker
+
+  def perform(feedback_params)
+    ContentImprovementFeedback.create!(feedback_params)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,12 @@ Rails.application.routes.draw do
               controller: "global_export_requests",
               as: "global_export_request"
 
+    resources "content_improvement",
+              only: [:create],
+              format: false,
+              controller: "content_improvement",
+              as: "content_improvement"
+
     get '/problem-reports/:date/totals',
         constraints: { date: /\d{4}-\d{2}-\d{2}/ },
         to: 'problem_reports#totals'

--- a/db/migrate/20190130105818_create_content_improvement_feedback.rb
+++ b/db/migrate/20190130105818_create_content_improvement_feedback.rb
@@ -1,0 +1,10 @@
+class CreateContentImprovementFeedback < ActiveRecord::Migration[5.2]
+  def change
+    create_table :content_improvement_feedbacks do |t|
+      t.string :description, null: false
+      t.boolean :reviewed, null: false, default: false
+      t.boolean :marked_as_spam, null: false, default: false
+      t.string :personal_information_status
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -149,6 +149,51 @@ ALTER SEQUENCE content_items_id_seq OWNED BY content_items.id;
 
 
 --
+-- Name: content_improvement_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE content_improvement_feedbacks (
+id bigint NOT NULL,
+description character varying NOT NULL,
+reviewed boolean DEFAULT false NOT NULL,
+marked_as_spam boolean DEFAULT false NOT NULL,
+personal_information_status character varying
+);
+
+
+--
+-- Name: content_improvement_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE content_improvement_feedbacks_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+
+--
+-- Name: content_improvement_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE content_improvement_feedbacks_id_seq OWNED BY content_improvement_feedbacks.id;
+
+
+--
+-- Name: content_improvement_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY content_improvement_feedbacks ALTER COLUMN id SET DEFAULT nextval('content_improvement_feedbacks_id_seq'::regclass);
+
+--
+-- Name: content_improvement_feedbacks content_improvement_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY content_improvement_feedbacks
+ADD CONSTRAINT content_improvement_feedbacks_pkey PRIMARY KEY (id);
+
+--
 -- Name: content_items_organisations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
@@ -472,4 +517,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171204155340'),
 ('20180108153838'),
 ('20180906145408'),
-('20181231135850');
+('20181231135850'),
+('20190130105818');

--- a/spec/factories/content_improvement_feedback.rb
+++ b/spec/factories/content_improvement_feedback.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :content_improvement_feedback, class: ContentImprovementFeedback do
+    description { 'something missing' }
+    personal_information_status { 'absent' }
+  end
+end

--- a/spec/models/content_improvement_feedback_spec.rb
+++ b/spec/models/content_improvement_feedback_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'field_which_may_contain_personal_information'
+
+describe ContentImprovementFeedback, type: :model do
+  def new_feedback(options = {})
+    build :content_improvement_feedback, options
+  end
+
+  def create_feedback(options = {})
+    create :content_improvement_feedback, options
+  end
+
+  it { should allow_value("something is missing").for(:description) }
+  it { should validate_length_of(:description).is_at_most(2**16) }
+  it { should validate_length_of(:description).is_at_least(1) }
+
+  it "validates the personal_information_status field" do
+    expect(new_feedback(personal_information_status: nil)).to be_valid
+    expect(new_feedback(personal_information_status: "suspected")).to be_valid
+    expect(new_feedback(personal_information_status: "absent")).to be_valid
+
+    expect(new_feedback(personal_information_status: "abcde")).to_not be_valid
+  end
+
+  it "notices when an email is present the description" do
+    expect(create_feedback(description: "contact me at name@domain.com please").personal_information_status).to eq("suspected")
+  end
+
+  it "notices when a national insurance number is present in the description" do
+    expect(create_feedback(description: "my NI number is QQ 12 34 56 A thanks").personal_information_status).to eq("suspected")
+  end
+end

--- a/spec/requests/content_improvement_feedback_spec.rb
+++ b/spec/requests/content_improvement_feedback_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe 'Content Improvement Feedback' do
+  let(:common_headers) { { "CONTENT_TYPE" => 'application/json', 'HTTP_ACCEPT' => 'application/json' } }
+  context 'successful post' do
+    before do
+      post '/anonymous-feedback/content_improvement',
+        params: { description: 'this thing is missing' }.to_json,
+        headers: common_headers
+    end
+
+    it 'responds successfully' do
+      expect(response.status).to eq(202)
+    end
+
+    it 'creates a ContentImprovementFeedback with correct description' do
+      expect(ContentImprovementFeedback.all.first).to have_attributes(
+        description: 'this thing is missing',
+        reviewed: false,
+        marked_as_spam: false,
+        personal_information_status: 'absent'
+      )
+    end
+  end
+
+  context 'when the message contains personal information' do
+    before do
+      post '/anonymous-feedback/content_improvement',
+        params: { description: 'contact me at user@domain.com' }.to_json,
+        headers: common_headers
+    end
+
+    it 'responds successfully' do
+      expect(response.status).to eq(202)
+    end
+
+    it 'marks the feedback personal_information_status as `suspected`' do
+      expect(ContentImprovementFeedback.all.first).to have_attributes(
+        description: 'contact me at user@domain.com',
+        reviewed: false,
+        marked_as_spam: false,
+        personal_information_status: 'suspected'
+      )
+    end
+  end
+
+  context 'when the description is not supplied' do
+    it "returns an appropriate error" do
+      post '/anonymous-feedback/content_improvement',
+        params: {}.to_json,
+        headers: common_headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)["errors"]).to include(
+        "Description is too short (minimum is 1 character)",
+      )
+    end
+  end
+
+  context 'when the description is blank' do
+    it "returns an appropriate error" do
+      post '/anonymous-feedback/content_improvement',
+        params: { description: '' }.to_json,
+        headers: common_headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)["errors"]).to include(
+        "Description is too short (minimum is 1 character)",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/a9WXTd6f/64-build-a-feedback-component-to-sit-below-business-finder-results

# What
Add and endpoint to capture feedback from the EU Exit business finder.

# Why

We want to build a feedback component that sits at the bottom of the business finder results that allows users to tell us what's missing. 

There is a [related PR in feedback](https://github.com/alphagov/feedback/pull/630) that sends the feedback to support API