### PR TITLE
Specify ActiveRecord::Migration[4.2] for all existing migrations

### DIFF
--- a/db/migrate/20140728110134_change_user_agent_datatype.rb
+++ b/db/migrate/20140728110134_change_user_agent_datatype.rb
@@ -1,4 +1,4 @@
-class ChangeUserAgentDatatype < ActiveRecord::Migration
+class ChangeUserAgentDatatype < ActiveRecord::Migration[4.2]
   def change
     change_column :anonymous_contacts, :user_agent, :text
   end

--- a/db/migrate/20141002153042_make_path_a_string.rb
+++ b/db/migrate/20141002153042_make_path_a_string.rb
@@ -1,4 +1,4 @@
-class MakePathAString < ActiveRecord::Migration
+class MakePathAString < ActiveRecord::Migration[4.2]
   def change
     change_column :anonymous_contacts, :path, :string, limit: 2048
   end

--- a/db/migrate/20141002165103_allow_longer_referrers.rb
+++ b/db/migrate/20141002165103_allow_longer_referrers.rb
@@ -1,4 +1,4 @@
-class AllowLongerReferrers < ActiveRecord::Migration
+class AllowLongerReferrers < ActiveRecord::Migration[4.2]
   def change
     change_column :anonymous_contacts, :referrer, :string, limit: 2048
   end

--- a/db/migrate/20141230121133_add_content_items_and_organisations.rb
+++ b/db/migrate/20141230121133_add_content_items_and_organisations.rb
@@ -1,4 +1,4 @@
-class AddContentItemsAndOrganisations < ActiveRecord::Migration
+class AddContentItemsAndOrganisations < ActiveRecord::Migration[4.2]
   def change
     create_table :content_items do |t|
       t.string "path", limit: 2048, null: false

--- a/db/migrate/20150115215320_add_index_on_anonymous_contacts_path.rb
+++ b/db/migrate/20150115215320_add_index_on_anonymous_contacts_path.rb
@@ -1,4 +1,4 @@
-class AddIndexOnAnonymousContactsPath < ActiveRecord::Migration
+class AddIndexOnAnonymousContactsPath < ActiveRecord::Migration[4.2]
   def change
     add_index "anonymous_contacts", ["path"], name: "index_anonymous_contacts_on_path", using: :btree
   end

--- a/db/migrate/20150313183713_remove_low_quality_single_word_feedback.rb
+++ b/db/migrate/20150313183713_remove_low_quality_single_word_feedback.rb
@@ -1,4 +1,4 @@
-class RemoveLowQualitySingleWordFeedback < ActiveRecord::Migration
+class RemoveLowQualitySingleWordFeedback < ActiveRecord::Migration[4.2]
   class Support::Requests::Anonymous::ProblemReport; end
 
   def up

--- a/db/migrate/20150430133750_replace_empty_paths.rb
+++ b/db/migrate/20150430133750_replace_empty_paths.rb
@@ -1,4 +1,4 @@
-class ReplaceEmptyPaths < ActiveRecord::Migration
+class ReplaceEmptyPaths < ActiveRecord::Migration[4.2]
   class ProblemReport < ApplicationRecord; end
 
   def up

--- a/db/migrate/20150505100000_replace_empty_or_null_paths.rb
+++ b/db/migrate/20150505100000_replace_empty_or_null_paths.rb
@@ -1,4 +1,4 @@
-class ReplaceEmptyOrNullPaths < ActiveRecord::Migration
+class ReplaceEmptyOrNullPaths < ActiveRecord::Migration[4.2]
   def up
     Support::Requests::Anonymous::AnonymousContact.
       unscoped.

--- a/db/migrate/20150505162618_path_not_null.rb
+++ b/db/migrate/20150505162618_path_not_null.rb
@@ -1,4 +1,4 @@
-class PathNotNull < ActiveRecord::Migration
+class PathNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column :anonymous_contacts, :path, :string, limit: 2048, null: false
   end

--- a/db/migrate/20150513094727_drop_anonymous_contacts_url.rb
+++ b/db/migrate/20150513094727_drop_anonymous_contacts_url.rb
@@ -1,4 +1,4 @@
-class DropAnonymousContactsUrl < ActiveRecord::Migration
+class DropAnonymousContactsUrl < ActiveRecord::Migration[4.2]
   def change
     remove_column :anonymous_contacts, :url
   end

--- a/db/migrate/20150515222831_remove_module_on_anonymous_contacts_sti_type_column.rb
+++ b/db/migrate/20150515222831_remove_module_on_anonymous_contacts_sti_type_column.rb
@@ -1,4 +1,4 @@
-class RemoveModuleOnAnonymousContactsStiTypeColumn < ActiveRecord::Migration
+class RemoveModuleOnAnonymousContactsStiTypeColumn < ActiveRecord::Migration[4.2]
   def up
     execute "UPDATE anonymous_contacts SET type = REPLACE(type, 'Support::Requests::Anonymous::', '')"
   end

--- a/db/migrate/20150518151221_add_index_to_anonymous_contacts_on_created_at.rb
+++ b/db/migrate/20150518151221_add_index_to_anonymous_contacts_on_created_at.rb
@@ -1,4 +1,4 @@
-class AddIndexToAnonymousContactsOnCreatedAt < ActiveRecord::Migration
+class AddIndexToAnonymousContactsOnCreatedAt < ActiveRecord::Migration[4.2]
   def change
   	add_index "anonymous_contacts", ["created_at"], name: "index_anonymous_contacts_on_created_at", using: :btree
   end

--- a/db/migrate/20150521102732_add_organisation_acronym_and_status.rb
+++ b/db/migrate/20150521102732_add_organisation_acronym_and_status.rb
@@ -1,4 +1,4 @@
-class AddOrganisationAcronymAndStatus < ActiveRecord::Migration
+class AddOrganisationAcronymAndStatus < ActiveRecord::Migration[4.2]
   def change
     add_column :organisations, :acronym, :string, limit: 255
     add_column :organisations, :govuk_status, :string, limit: 255

--- a/db/migrate/20150521140644_add_content_id_to_organisations.rb
+++ b/db/migrate/20150521140644_add_content_id_to_organisations.rb
@@ -1,4 +1,4 @@
-class AddContentIdToOrganisations < ActiveRecord::Migration
+class AddContentIdToOrganisations < ActiveRecord::Migration[4.2]
   def change
     add_column :organisations, :content_id, :string, limit: 255
     add_index :organisations, [:content_id], name: "index_organisations_on_content_id", using: :btree

--- a/db/migrate/20150521144116_fill_organisation_content_ids.rb
+++ b/db/migrate/20150521144116_fill_organisation_content_ids.rb
@@ -1,6 +1,6 @@
 require 'gds_api/content_register'
 
-class FillOrganisationContentIds < ActiveRecord::Migration
+class FillOrganisationContentIds < ActiveRecord::Migration[4.2]
   def up
     return if Organisation.count == 0
 

--- a/db/migrate/20150522151256_create_feedback_export_requests.rb
+++ b/db/migrate/20150522151256_create_feedback_export_requests.rb
@@ -1,4 +1,4 @@
-class CreateFeedbackExportRequests < ActiveRecord::Migration
+class CreateFeedbackExportRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_export_requests do |t|
       t.string :notification_email, null: false

--- a/db/migrate/20150526095541_add_index_for_organisation_summary.rb
+++ b/db/migrate/20150526095541_add_index_for_organisation_summary.rb
@@ -1,4 +1,4 @@
-class AddIndexForOrganisationSummary < ActiveRecord::Migration
+class AddIndexForOrganisationSummary < ActiveRecord::Migration[4.2]
   def change
     add_index :anonymous_contacts, [:content_item_id, :created_at]
   end

--- a/db/migrate/20150604140707_serialise_export_filters.rb
+++ b/db/migrate/20150604140707_serialise_export_filters.rb
@@ -1,4 +1,4 @@
-class SerialiseExportFilters < ActiveRecord::Migration
+class SerialiseExportFilters < ActiveRecord::Migration[4.2]
   def up
     add_column :feedback_export_requests, :filters, :text
 

--- a/db/migrate/20150611133227_remove_blank_dates.rb
+++ b/db/migrate/20150611133227_remove_blank_dates.rb
@@ -1,4 +1,4 @@
-class RemoveBlankDates < ActiveRecord::Migration
+class RemoveBlankDates < ActiveRecord::Migration[4.2]
   def up
     # PostgreSQL can't have blank dates anyway.
     return if SupportApi.postgresql?

--- a/db/migrate/20150612130729_add_path_index_for_anonymous_contacts.rb
+++ b/db/migrate/20150612130729_add_path_index_for_anonymous_contacts.rb
@@ -1,4 +1,4 @@
-class AddPathIndexForAnonymousContacts < ActiveRecord::Migration
+class AddPathIndexForAnonymousContacts < ActiveRecord::Migration[4.2]
   def up
     if SupportApi.postgresql?
       execute <<-SQL

--- a/db/migrate/20150623151655_add_path_index_with_varchar_pattern_ops.rb
+++ b/db/migrate/20150623151655_add_path_index_with_varchar_pattern_ops.rb
@@ -1,4 +1,4 @@
-class AddPathIndexWithVarcharPatternOps < ActiveRecord::Migration
+class AddPathIndexWithVarcharPatternOps < ActiveRecord::Migration[4.2]
   def up
     remove_index :anonymous_contacts, :path
 

--- a/db/migrate/20150915134640_deduplicate_organisations.rb
+++ b/db/migrate/20150915134640_deduplicate_organisations.rb
@@ -1,4 +1,4 @@
-class DeduplicateOrganisations < ActiveRecord::Migration
+class DeduplicateOrganisations < ActiveRecord::Migration[4.2]
   class Organisation < ApplicationRecord
     has_and_belongs_to_many :content_items
   end

--- a/db/migrate/20151202212408_clean_up_org_without_content_id.rb
+++ b/db/migrate/20151202212408_clean_up_org_without_content_id.rb
@@ -1,4 +1,4 @@
-class CleanUpOrgWithoutContentId < ActiveRecord::Migration
+class CleanUpOrgWithoutContentId < ActiveRecord::Migration[4.2]
   def change
     orgs_without_a_content_id = Organisation.where(content_id: nil).count
     raise "Unexpected number (#{orgs_without_a_content_id}) of organisations without a content_id" if orgs_without_a_content_id > 1

--- a/db/migrate/20151203001139_make_organisation_content_ids_not_null.rb
+++ b/db/migrate/20151203001139_make_organisation_content_ids_not_null.rb
@@ -1,4 +1,4 @@
-class MakeOrganisationContentIdsNotNull < ActiveRecord::Migration
+class MakeOrganisationContentIdsNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column :organisations, :content_id, :string, limit: 255, null: false
   end

--- a/db/migrate/20160511164547_create_archived_service_feedback.rb
+++ b/db/migrate/20160511164547_create_archived_service_feedback.rb
@@ -1,4 +1,4 @@
-class CreateArchivedServiceFeedback < ActiveRecord::Migration
+class CreateArchivedServiceFeedback < ActiveRecord::Migration[4.2]
   def change
     create_table :archived_service_feedbacks do |t|
       t.string :type

--- a/db/migrate/20160822145924_add_marked_as_spam_to_anonymous_contacts.rb
+++ b/db/migrate/20160822145924_add_marked_as_spam_to_anonymous_contacts.rb
@@ -1,4 +1,4 @@
-class AddMarkedAsSpamToAnonymousContacts < ActiveRecord::Migration
+class AddMarkedAsSpamToAnonymousContacts < ActiveRecord::Migration[4.2]
   def change
     add_column :anonymous_contacts, :marked_as_spam, :boolean, null: false, default: false
   end

--- a/db/migrate/20160826105129_add_reviewed_to_anonymous_contacts.rb
+++ b/db/migrate/20160826105129_add_reviewed_to_anonymous_contacts.rb
@@ -1,4 +1,4 @@
-class AddReviewedToAnonymousContacts < ActiveRecord::Migration
+class AddReviewedToAnonymousContacts < ActiveRecord::Migration[4.2]
   def change
     add_column :anonymous_contacts, :reviewed, :boolean, null: false, default: false
   end


### PR DESCRIPTION
- We were seeing errors in Sentry related to these not being specified:
  https://sentry.io/organizations/govuk/issues/971865094/?project=202256&query=is%3Aunresolved+environment%3Astaging