### PR TITLE
Allow querying for anonymous feedback using POST

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
             only: :index,
             format: false,
             controller: "anonymous_feedback",
-            as: "anonymous_feedback"
+            as: "anonymous_feedback" do
+              post :index
+            end
 
   scope "anonymous-feedback", module: "anonymous_feedback" do
     resources "service-feedback",

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -351,5 +351,37 @@ describe AnonymousFeedbackController, type: :controller do
         end
       end
     end
+
+    context "when using POST as the HTTP method" do
+      context "with an existing content item" do
+        let(:content_item) do
+          create(:content_item, document_type: 'smart_answer', path: "/calculate-your-holiday-entitlement")
+        end
+
+        before do
+          create(:problem_report, content_item: content_item)
+        end
+
+        it "returns the content item in the results when searching for it" do
+          post :index, params: { document_type: 'smart_answer' }
+
+          expect(response).to be_successful
+          expect(json_response["total_count"]).to eq(1)
+        end
+
+        it "returns an empty result when no searching for something else" do
+          post :index, params: { path_prefixes: ["/non-existent"] }
+
+          expect(response).to be_successful
+          expect(json_response).to eq(
+            "results" => [],
+            "page_size" => 50,
+            "total_count" => 0,
+            "current_page" => 1,
+            "pages" => 0,
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently the only way to perform a query against anonymous feedback using support-api is via a GET. This limits the number of paths that can be passed in to the limit of a URL length. In practice, this means you can only query on at most 30 URLs. The analytics team would like to be able to run queries with more than 30 URLs.

This is the first part of a bigger to change which will also see the support app use POST to run these queries.

[Trello Card](https://trello.com/c/EGvu5WoK/757-make-feedex-able-to-return-results-for-larger-sets-of-urls-by-changing-request-from-get-to-post)