### PR TITLE
Correctly allow POST requests to anonymous feedback endpoint

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -24,7 +24,7 @@ class AnonymousFeedbackController < ApplicationController
     render json: json
   end
 
-  private
+private
 
   def at_least_one_param_present?
     params[:organisation_slug].present? || params[:path_prefixes].present? || params[:document_type].present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,6 @@
 Rails.application.routes.draw do
-  resources "anonymous-feedback",
-            only: :index,
-            format: false,
-            controller: "anonymous_feedback",
-            as: "anonymous_feedback" do
-              post :index
-            end
+  get "/anonymous-feedback", to: "anonymous_feedback#index"
+  post "/anonymous-feedback", to: "anonymous_feedback#index"
 
   scope "anonymous-feedback", module: "anonymous_feedback" do
     resources "service-feedback",


### PR DESCRIPTION
This follows on from https://github.com/alphagov/support-api/pull/305. Unfortunately that method only appeared to work because the tests were passing, but it doesn't actually set up the correct routes because of the `only: :index`. There doesn't appear to be a way to allow the `create` method of a resource to point to the same action as the `index` action, so instead I've made the routes explicit.

An alternative would have been to put this in the controller, but I decided it was better to keep the controller clean:

```ruby
def create; index; end
```

[Trello Card](https://trello.com/c/EGvu5WoK/757-make-feedex-able-to-return-results-for-larger-sets-of-urls-by-changing-request-from-get-to-post)