### PR TITLE
Fix talking to the Organisations API

### DIFF
--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -1,4 +1,4 @@
-require "gds_api/organisations"
+require "gds_api"
 
 class OrganisationImporter
   def run
@@ -64,6 +64,6 @@ private
   end
 
   def organisations_api
-    @organisations_api ||= GdsApi::Organisations.new(Plek.current.find("whitehall-admin"))
+    @organisations_api ||= GdsApi.organisations
   end
 end


### PR DESCRIPTION
It used to be in Whitehall Admin, but has now moved to
Collections. Switch to using the helper method from the GdsApi module,
so that the default from the gds-api-adapters is used.