### PR TITLE
Make global export requests proxy files through support app

### DIFF
--- a/app/workers/generate_global_export_csv_worker.rb
+++ b/app/workers/generate_global_export_csv_worker.rb
@@ -4,14 +4,20 @@ class GenerateGlobalExportCsvWorker
   include Sidekiq::Worker
 
   def perform(export_params)
+    feedback_export_request = FeedbackExportRequest.new(notification_email: export_params["notification_email"])
+
     filename, contents = GlobalExportCsvGenerator.new(
       Date.strptime(export_params["from_date"], "%Y-%m-%d").beginning_of_day,
       Date.strptime(export_params["to_date"], "%Y-%m-%d").end_of_day,
       export_params["exclude_spam"],
     ).call
 
+    feedback_export_request.filename = filename
+
     s3_file = S3FileUploader.save_file_to_s3(filename, contents)
 
-    GlobalExportNotification.notification_email(export_params["notification_email"], s3_file.public_url).deliver_now
+    feedback_export_request.save!
+
+    GlobalExportNotification.notification_email(export_params["notification_email"], feedback_export_request.url).deliver_now
   end
 end

--- a/app/workers/generate_global_export_csv_worker.rb
+++ b/app/workers/generate_global_export_csv_worker.rb
@@ -17,6 +17,7 @@ class GenerateGlobalExportCsvWorker
     S3FileUploader.save_file_to_s3(filename, contents)
 
     feedback_export_request.save!
+    feedback_export_request.touch(:generated_at)
 
     GlobalExportNotification.notification_email(export_params["notification_email"], feedback_export_request.url).deliver_now
   end

--- a/app/workers/generate_global_export_csv_worker.rb
+++ b/app/workers/generate_global_export_csv_worker.rb
@@ -14,7 +14,7 @@ class GenerateGlobalExportCsvWorker
 
     feedback_export_request.filename = filename
 
-    s3_file = S3FileUploader.save_file_to_s3(filename, contents)
+    S3FileUploader.save_file_to_s3(filename, contents)
 
     feedback_export_request.save!
 

--- a/lib/s3_file_uploader.rb
+++ b/lib/s3_file_uploader.rb
@@ -12,7 +12,6 @@ class S3FileUploader
     directory.files.create(
       key: filename,
       body: csv,
-      public: true,
     )
   end
 end

--- a/spec/workers/generate_global_export_csv_worker_spec.rb
+++ b/spec/workers/generate_global_export_csv_worker_spec.rb
@@ -28,7 +28,7 @@ describe GenerateGlobalExportCsvWorker, type: :worker do
     from_date = "2019-01-01"
     to_date = "2019-12-31"
     notification_email = "inside-government@digital.cabinet-office.gov.uk"
-    file_url = "https://#{ENV['AWS_S3_BUCKET_NAME']}.s3-eu-west-1.amazonaws.com/feedex_#{from_date}T00%3A00%3A00Z_#{to_date}T23%3A59%3A59Z.csv"
+    file_url = %r{^http://support.dev.gov.uk/anonymous_feedback/export_requests/\d+$}
 
     expect(GlobalExportNotification).to receive(:notification_email).with(notification_email, file_url).and_return(stub)
 
@@ -43,6 +43,5 @@ describe GenerateGlobalExportCsvWorker, type: :worker do
     rows = file.body.split("\n")
     expect(rows.count).to eq 1
     expect(rows.first).to eq "date,report_count"
-    expect(file.public_url).to eq file_url
   end
 end


### PR DESCRIPTION
Files can't be publicly accessible in the s3 bucket. Existing uploads are proxied through the support app which handles authentication and retrieves the file if permitted; this changes global export requests to use the same process.

https://trello.com/c/V9wtOj6x/1713-3-support-api-make-globalcsvexport-use-s3-instead-of-email-attachments