### PR TITLE
Use GOV.UK Notify for ActionMailer messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "gds-sso", "~> 14.2.0"
 gem "gds_zendesk", "3.0.0"
 gem "kaminari", "1.2.0"
 gem "mlanett-redis-lock", "0.2.7"
+gem "notifications-ruby-client"
 gem "plek", "3.0.0"
 gem "user_agent_parser"
 gem "whenever", "1.0.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.1.2)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
@@ -404,6 +406,7 @@ DEPENDENCIES
   kaminari (= 1.2.0)
   listen (~> 3.2.1)
   mlanett-redis-lock (= 0.2.7)
+  notifications-ruby-client
   pg (~> 1.2.2)
   plek (= 3.0.0)
   pry-byebug
@@ -421,4 +424,4 @@ DEPENDENCIES
   whenever (= 1.0.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,9 @@ module SupportApi
     config.action_dispatch.rack_cache = nil
 
     config.active_record.schema_format = :sql
+
+    config.after_initialize do
+      config.action_mailer.notify_settings = { api_key: Rails.application.secrets.notify_api_key }
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :file
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :notify
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,2 @@
+require "notify_delivery_method"
+ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,4 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -1,5 +1,5 @@
-require 'notifications/client'
-require 'mail'
+require "notifications/client"
+require "mail"
 
 class NotifyDeliveryMethod
   attr_reader :settings
@@ -12,7 +12,7 @@ class NotifyDeliveryMethod
     client.send_email(payload(mail))
   end
 
-  private
+private
 
   def client
     @client ||= Notifications::Client.new(settings[:notify_api_key])
@@ -20,7 +20,7 @@ class NotifyDeliveryMethod
 
   def payload(mail)
     if mail.to.length > 1
-      raise 'Sending emails with multiple recipients is not supported'
+      raise "Sending emails with multiple recipients is not supported"
     end
 
     {
@@ -28,8 +28,8 @@ class NotifyDeliveryMethod
       template_id: settings[:template_id],
       personalisation: {
         body: mail.body.raw_source,
-        subject: mail.subject
-      }
+        subject: mail.subject,
+      },
     }
   end
 end

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -1,0 +1,35 @@
+require 'notifications/client'
+require 'mail'
+
+class NotifyDeliveryMethod
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    client.send_email(payload(mail))
+  end
+
+  private
+
+  def client
+    @client ||= Notifications::Client.new(settings[:notify_api_key])
+  end
+
+  def payload(mail)
+    if mail.to.length > 1
+      raise 'Sending emails with multiple recipients is not supported'
+    end
+
+    {
+      email_address: mail.to.first,
+      template_id: settings[:template_id],
+      personalisation: {
+        body: mail.body.raw_source,
+        subject: mail.subject
+      }
+    }
+  end
+end

--- a/spec/lib/notify_delivery_method_spec.rb
+++ b/spec/lib/notify_delivery_method_spec.rb
@@ -1,49 +1,49 @@
-require 'rails_helper'
-require 'notify_delivery_method'
+require "rails_helper"
+require "notify_delivery_method"
 
 RSpec.describe NotifyDeliveryMethod do
-  describe '#deliver!' do
+  describe "#deliver!" do
     it "calls Notify's send_email endpoint" do
-      headers = { to: 'x@y.com',
-                  body: 'Body content',
-                  subject: 'A subject line' }
+      headers = { to: "x@y.com",
+                  body: "Body content",
+                  subject: "A subject line" }
 
       template_id = SecureRandom.uuid
       message = Mail::Message.new(headers)
       client = instance_double(Notifications::Client)
 
       allow(Notifications::Client).to receive(:new)
-        .with('api-key').and_return(client)
+        .with("api-key").and_return(client)
 
       expect(client).to receive(:send_email)
         .with(email_address: headers[:to],
               template_id: template_id,
               personalisation: {
                 body: headers[:body],
-                subject: headers[:subject]
+                subject: headers[:subject],
               })
 
-      method = NotifyDeliveryMethod.new(notify_api_key: 'api-key', template_id: template_id)
+      method = NotifyDeliveryMethod.new(notify_api_key: "api-key", template_id: template_id)
       method.deliver!(message)
     end
 
-    it 'raises an exception for multiple recipients' do
-      headers = { to: ['x@y.com', 'a@b.com'],
-                  body: 'Body content',
-                  subject: 'A subject line' }
+    it "raises an exception for multiple recipients" do
+      headers = { to: ["x@y.com", "a@b.com"],
+                  body: "Body content",
+                  subject: "A subject line" }
 
       template_id = SecureRandom.uuid
       message = Mail::Message.new(headers)
       client = instance_double(Notifications::Client)
 
       allow(Notifications::Client).to receive(:new)
-        .with('api-key').and_return(client)
+        .with("api-key").and_return(client)
 
-      method = NotifyDeliveryMethod.new(notify_api_key: 'api-key', template_id: template_id)
+      method = NotifyDeliveryMethod.new(notify_api_key: "api-key", template_id: template_id)
 
       expect { method.deliver!(message) }.to raise_error(
         RuntimeError,
-        'Sending emails with multiple recipients is not supported'
+        "Sending emails with multiple recipients is not supported",
       )
     end
   end

--- a/spec/lib/notify_delivery_method_spec.rb
+++ b/spec/lib/notify_delivery_method_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'notify_delivery_method'
+
+RSpec.describe NotifyDeliveryMethod do
+  describe '#deliver!' do
+    it "calls Notify's send_email endpoint" do
+      headers = { to: 'x@y.com',
+                  body: 'Body content',
+                  subject: 'A subject line' }
+
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
+      client = instance_double(Notifications::Client)
+
+      allow(Notifications::Client).to receive(:new)
+        .with('api-key').and_return(client)
+
+      expect(client).to receive(:send_email)
+        .with(email_address: headers[:to],
+              template_id: template_id,
+              personalisation: {
+                body: headers[:body],
+                subject: headers[:subject]
+              })
+
+      method = NotifyDeliveryMethod.new(notify_api_key: 'api-key', template_id: template_id)
+      method.deliver!(message)
+    end
+
+    it 'raises an exception for multiple recipients' do
+      headers = { to: ['x@y.com', 'a@b.com'],
+                  body: 'Body content',
+                  subject: 'A subject line' }
+
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
+      client = instance_double(Notifications::Client)
+
+      allow(Notifications::Client).to receive(:new)
+        .with('api-key').and_return(client)
+
+      method = NotifyDeliveryMethod.new(notify_api_key: 'api-key', template_id: template_id)
+
+      expect { method.deliver!(message) }.to raise_error(
+        RuntimeError,
+        'Sending emails with multiple recipients is not supported'
+      )
+    end
+  end
+end


### PR DESCRIPTION
We want to switch to using GOV.UK Notify instead of Amazon SES for emails. This instantiates the Notify client and configures ActionMailer to use it.

https://trello.com/c/GZ142gQv/1730-5-support-api-use-notify-instead-of-amazon-ses-%F0%9F%8D%90