### PR TITLE
Pass through Notify configuration parameters

### DIFF
--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,2 +1,5 @@
 require "notify_delivery_method"
-ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod
+
+ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod,
+                                       notify_api_key: Rails.application.secrets.notify_api_key,
+                                       template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"]


### PR DESCRIPTION
Notify needs an API key and template ID; pass these through from the environment (puppet/secrets) when instantiating a mailer.
