### PR TITLE
rubocop: Set `inherit_mode: merge` for Excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'


### PR DESCRIPTION
- We found that for apps that used Ruby-only cops, the recent changes in
  gem version 3.1.0 to exclude `bin/` files from linting worked fine.
- For apps that used Rails cops as well, the changes didn't work for
  `bin/` but they did work for `db/schema.rb` which is excluded from
  linting in `config/rails.yml`.
- This is because RuboCop by default *overwrites* any previous
  definitions of a config option when it detects a later one:
  https://rubocop.readthedocs.io/en/latest/configuration/#merging-arrays-using-inherit_mode.
- Unfortunately, we'll have to specify this `inherit_mode` stanza in
  every app.

https://trello.com/c/i72oq9Xa/1810-fix-rubocop-config-file-inheritance-in-all-the-apps