### PR TITLE
Amend indentation autocorrect by rubocop

### DIFF
--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -14,21 +14,29 @@ describe ContentItem do
   end
 
   it "calculates anonymous feedback counts for recent time intervals" do
-    create(:content_item, organisations: orgs, path: "/abc",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 5.days.ago),
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                            create(:anonymous_contact, created_at: 70.days.ago),
-                            create(:anonymous_contact, created_at: 100.days.ago),
-                          ])
+    create(
+      :content_item,
+      organisations: orgs,
+      path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 5.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 100.days.ago),
+      ],
+    )
 
-    create(:content_item, organisations: orgs, path: "/def",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 60.days.ago),
-                            create(:anonymous_contact, created_at: 70.days.ago),
-                            create(:anonymous_contact, created_at: 80.days.ago),
-                            create(:anonymous_contact, created_at: 90.days.ago),
-                          ])
+    create(
+      :content_item,
+      organisations: orgs,
+      path: "/def",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 60.days.ago),
+        create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 80.days.ago),
+        create(:anonymous_contact, created_at: 90.days.ago),
+      ],
+    )
 
     expect(ContentItem.summary).to eq([
       { path: "/abc", last_7_days: 1, last_30_days: 2, last_90_days: 3 },
@@ -47,16 +55,25 @@ describe ContentItem do
   end
 
   it "aggregates content items with similar paths" do
-    create(:content_item, organisations: orgs, path: "/abc",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                          ])
-    create(:content_item, organisations: orgs, path: "/abc",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                          ])
+    create(
+      :content_item,
+      organisations: orgs,
+      path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+      ],
+    )
+
+    create(
+      :content_item,
+      organisations: orgs,
+      path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 15.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+      ],
+    )
 
     expect(ContentItem.summary).to eq([
       { path: "/abc", last_7_days: 0, last_30_days: 4, last_90_days: 4 },

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -25,18 +25,26 @@ describe "Organisations that have feedback left on 'their' content" do
   let!(:hmrc) { create(:organisation, hmrc_info) }
 
   before do
-    create(:content_item, organisations: [ukvi], path: "/abc",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 5.days.ago),
-                            create(:anonymous_contact, created_at: 15.days.ago),
-                          ])
+    create(
+      :content_item,
+      organisations: [ukvi],
+      path: "/abc",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 5.days.ago),
+        create(:anonymous_contact, created_at: 15.days.ago),
+      ],
+    )
 
-    create(:content_item, organisations: [ukvi], path: "/def",
-                          anonymous_contacts: [
-                            create(:anonymous_contact, created_at: 70.days.ago),
-                            create(:anonymous_contact, created_at: 75.days.ago),
-                            create(:anonymous_contact, created_at: 80.days.ago),
-                          ])
+    create(
+      :content_item,
+      organisations: [ukvi],
+      path: "/def",
+      anonymous_contacts: [
+        create(:anonymous_contact, created_at: 70.days.ago),
+        create(:anonymous_contact, created_at: 75.days.ago),
+        create(:anonymous_contact, created_at: 80.days.ago),
+      ],
+    )
   end
 
   it "can be retrieved (so that it's possible to not deal with orgs that have no feedback)" do


### PR DESCRIPTION
In https://github.com/alphagov/support-api/pull/462 rubocop "fixed" the
indentation and in these few cases it didn't do a great job.

This applies a more consistent indentation which is both accepted by
rubocop and more widely used.