### PR TITLE
Always print coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,13 +35,12 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop-govuk"
   gem "shoulda-matchers"
-  gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "timecop"
 end
 
 group :test do
   gem "factory_bot_rails"
   gem "pry-byebug"
+  gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,8 +341,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -416,7 +414,6 @@ DEPENDENCIES
   rubocop-govuk
   shoulda-matchers
   simplecov
-  simplecov-rcov
   spring
   spring-watcher-listen
   timecop

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,8 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+SimpleCov.start "rails"
+
 require "spec_helper"
 require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-require "simplecov"
-require "simplecov-rcov"
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start "rails"
-
 RSpec.configure do |config|
   config.after(:each) do
     Timecop.return


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that the RCov formatter is optional, and we can still see a
webpage of the detailed coverage.