### PR TITLE
Don't schedule Rake tasks outside of the Production environment

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,32 +6,34 @@ set :output, error: "log/cron.error.log", standard: "log/cron.log"
 # We need Rake to use our own environment
 job_type :rake, "cd :path && govuk_setenv support-api bundle exec rake :task :output"
 
-every 1.month, at: "12:40 am" do
-  rake "performance_platform_uploads:push_problem_report_stats"
-end
+if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/
+  every 1.month, at: "12:40 am" do
+    rake "performance_platform_uploads:push_problem_report_stats"
+  end
 
-every 1.day, at: "12:10 am" do
-  rake "anonymous_feedback_deduplication:nightly"
-end
+  every 1.day, at: "12:10 am" do
+    rake "anonymous_feedback_deduplication:nightly"
+  end
 
-every 1.day, at: "12:20 am" do
-  rake "api_sync:import_organisations"
-end
+  every 1.day, at: "12:20 am" do
+    rake "api_sync:import_organisations"
+  end
 
-every 1.day, at: "12:30 am" do
-  rake "service_feedback_aggregation:daily"
-end
+  every 1.day, at: "12:30 am" do
+    rake "service_feedback_aggregation:daily"
+  end
 
-every 1.day, at: "1:30 am" do
-  # The service feedback aggregation task must have completed before this one,
-  # that's why we give it an hour to complete before triggering.
-  rake "performance_platform_uploads:push_service_feedback"
-end
+  every 1.day, at: "1:30 am" do
+    # The service feedback aggregation task must have completed before this one,
+    # that's why we give it an hour to complete before triggering.
+    rake "performance_platform_uploads:push_service_feedback"
+  end
 
-every 1.day, at: "1:40 am" do
-  rake "performance_platform_uploads:push_problem_report_daily_totals"
-end
+  every 1.day, at: "1:40 am" do
+    rake "performance_platform_uploads:push_problem_report_daily_totals"
+  end
 
-every 5.minutes, at: 3 do
-  rake "anonymous_feedback_deduplication:recent"
+  every 5.minutes, at: 3 do
+    rake "anonymous_feedback_deduplication:recent"
+  end
 end


### PR DESCRIPTION
We're seeing a number of errors in Sentry as a result of at least
two workers (but probably more): `ProblemReportStatsPPUploaderWorker`
and `ProblemReportDailyTotalsPPUploaderWorker`.

These result in `GdsApi::SocketErrorException` timeouts on
Integration, most likely as a result of the nightly data sync,
where the dependent services (e.g. Performance Platform) are
temporarily down.

We shouldn't care about running these scheduled tasks on
Integration and Staging, particularly as they're all timed during
the data sync. It is better instead to let the tasks happen on
Production and wait for the nightly data sync to copy the results
over to Staging and Integration.

This does mean that Production may be 24 hours 'ahead' of the
other environments, but given that Performance Platform is being
retired, I don't see this as being an issue.

This should fix
https://sentry.io/organizations/govuk/issues/824216917/events/?project=202256&statsPeriod=24h
which has happened 20k times in 2 years.