### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,8 +67,6 @@ Rails.application.routes.draw do
 
   get "/feedback-by-day/:date", to: "feedback_by_day#index", format: false
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-describe "healthcheck path" do
-  it "responds with 'OK'" do
-    get "/healthcheck"
-    expect(response).to be_successful
-    expect(response.body).to eq("OK")
-  end
-end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
