### PR TITLE
Use Postgres13 for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 library("govuk")
 
 node {
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/support-api-test")
   govuk.buildProject(
     overrideTestTask: {
       stage("Run custom tests") {


### PR DESCRIPTION
Uses Postgres13 for CI by setting the TEST_DATABASE_URL environment variable.

- Confirmed CI on [this](https://ci.integration.publishing.service.gov.uk/job/support-api/job/postgres_13_test/1/console) branch (`Dropped database 'support-api-test'`) was building a different database than on the [main](https://ci.integration.publishing.service.gov.uk/job/support-api/job/main/518/console) branch (`Dropped database 'support_api_test'`)
- Confirmed tests pass

Trello:

https://trello.com/c/lYPj0Poj/7-support-api

https://trello.com/c/B21t1VAD/956-upgrade-support-api-from-postgres-96-to-postgres-13