### PR TITLE
Increase code coverage in advance of enabling CD

### DIFF
--- a/spec/lib/distributed_lock_spec.rb
+++ b/spec/lib/distributed_lock_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+require "distributed_lock"
+
+describe DistributedLock do
+  describe ".lock" do
+    context "when it runs successfully" do
+      it "returns the block value" do
+        result = described_class.new("lock_name").lock { :complete }
+        expect(result).to eq(:complete)
+      end
+    end
+
+    context "when it fails to acquire a lock within the timeout" do
+      before do
+        allow(Redis.current).to receive(:lock) do
+          raise Redis::Lock::LockNotAcquired
+        end
+      end
+
+      it "supresses the exception and logs a debug message" do
+        run = -> { described_class.new("lock_name").lock { :complete } }
+
+        expect(Rails.logger).to receive(:debug)
+        expect { run.call }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/presenters/problem_report_presenter_spec.rb
+++ b/spec/presenters/problem_report_presenter_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe ProblemReportPresenter do
+  describe "#initialize" do
+    it "takes a ProblemReport as an argument" do
+      expect { described_class.new }.to raise_exception(ArgumentError)
+      expect { described_class.new(build(:problem_report)) }.not_to raise_exception
+    end
+  end
+
+  describe ".header_row" do
+    it "returns an array of header names" do
+      expect(described_class.header_row).to eq([
+        "where feedback was left",
+        "creation date",
+        "feedback",
+        "user came from",
+      ])
+    end
+  end
+
+  describe "#to_a" do
+    it "presents the correct columns" do
+      problem_report = build(
+        :problem_report,
+        created_at: Time.utc(2015, 4),
+        what_doing: "Finding the thing",
+        what_wrong: "Couldn't find the thing\nThanks",
+      )
+
+      expect(described_class.new(problem_report).to_a).to eq([
+        "http://www.dev.gov.uk/vat-rates",
+        "2015-04-01",
+        "action: Finding the thing\nproblem: Couldn't find the thing\nThanks",
+        "http://www.example.com/foo",
+      ])
+    end
+  end
+end

--- a/spec/workers/content_item_enrichment_worker_spec.rb
+++ b/spec/workers/content_item_enrichment_worker_spec.rb
@@ -31,27 +31,4 @@ describe ContentItemEnrichmentWorker do
       end
     end
   end
-
-  context "with an entry in the content store" do
-    before do
-      create(:gds)
-      stub_content_store_has_item(path)
-    end
-
-    context "without an existing content item" do
-      it "creates a new content item" do
-        expect(ContentItem.count).to eq(0)
-        worker.perform(problem_report.id)
-        expect(ContentItem.count).to eq(1)
-      end
-    end
-
-    context "with an existing content item" do
-      it "uses the existing content item" do
-        create(:content_item, path: path)
-
-        expect { worker.perform(problem_report.id) }.to_not(change { ContentItem.count })
-      end
-    end
-  end
 end

--- a/spec/workers/content_item_populate_doctype_worker_spec.rb
+++ b/spec/workers/content_item_populate_doctype_worker_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+require "gds_api/test_helpers/content_store"
+
+describe ContentItemPopulateDoctypeWorker do
+  include GdsApi::TestHelpers::ContentStore
+
+  it "updates every content item's `document_type`" do
+    content_item = double("ContentItem", path: "foo")
+    allow(ContentItem).to receive(:all).and_return([content_item])
+    mock_content_store = double("ContentStore", content_item: { "document_type" => "foo_doctype" })
+    allow(GdsApi::ContentStore).to receive(:new).and_return(mock_content_store)
+
+    expect(content_item).to receive(:update!).with(document_type: "foo_doctype")
+
+    described_class.new.perform
+  end
+end


### PR DESCRIPTION
This PR increases code coverage from 90.86% to 96.56%, in preparation for enabling Continuous Deployment, which has an advisory code coverage minimum of 95% ([1]).

Trello: https://trello.com/c/855eZgel/2850-enable-continuous-deployment-for-support-api-3

[1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#check-internal-repo-tests-pass-ie-features-are-tested-in-detail