### PR TITLE
Specify Notify delivery method

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
     api_key: Rails.application.secrets.notify_api_key,
   }


### PR DESCRIPTION
This was removed as part of the Rails 7 upgrade. It was discussed
a little here:
https://github.com/alphagov/support-api/pull/628#discussion_r832024631

In retrospect, this has caused emails to fail to be sent. Related
Zendesk tickets:

- https://govuk.zendesk.com/agent/tickets/4932239
- https://govuk.zendesk.com/agent/tickets/4931891
- https://govuk.zendesk.com/agent/tickets/4927683