### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "6067c3169bffef56f180c4a4d85a2973f1e33d237a9293d4a130f83e8be3f854",
+      "fingerprint": "4850ceb993b6f05ea62bc58350d338c34e20990f4d3ee5934bca2e614cdecc57",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/distributed_lock.rb",
       "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.current.lock(\"support-api:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
+      "code": "Redis.new.lock(\"support-api:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
       "render_path": null,
       "location": {
         "type": "method",
@@ -61,6 +61,6 @@
       "note": "No user data."
     }
   ],
-  "updated": "2021-01-18 09:27:09 +0000",
-  "brakeman_version": "4.10.1"
+  "updated": "2022-10-06 11:38:00 +0100",
+  "brakeman_version": "5.2.3"
 }

--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -9,7 +9,7 @@ class DistributedLock
   end
 
   def lock
-    Redis.current.lock("support-api:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
+    Redis.new.lock("support-api:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
       Rails.logger.debug("Successfully got a lock. Running...")
       yield
     end

--- a/spec/lib/distributed_lock_spec.rb
+++ b/spec/lib/distributed_lock_spec.rb
@@ -12,7 +12,7 @@ describe DistributedLock do
 
     context "when it fails to acquire a lock within the timeout" do
       before do
-        allow(Redis.current).to receive(:lock) do
+        allow(Redis.new).to receive(:lock) do
           raise Redis::Lock::LockNotAcquired
         end
       end


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)