### PR TITLE
Dockerised app to meet replatforming standards.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.dockerignore
+.git
+.gitignore
+.github
+Dockerfile
+Jenkinsfile
+README.md
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+
+FROM $builder_image AS builder
+
+WORKDIR /app
+
+COPY Gemfile* .ruby-version /app/
+
+RUN bundle install
+
+COPY . /app
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=support-api
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app /app/
+
+USER app
+
+CMD bundle exec puma

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,5 +1,0 @@
-require "gds_api/base"
-
-if %w[development test].include? Rails.env
-  GdsApi::Base.default_options = { disable_cache: true }
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,4 +4,6 @@
 ---
 :verbose: true
 :concurrency: 2
-:logfile: ./log/sidekiq.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>


### PR DESCRIPTION
  Add Dockerfile which is standard we use for Ruby Apps
  Add .dockerignore to keeps image clean
  Adds Puma via govuk_app_config

https://trello.com/c/44ebF691/1026-publishing-journey-apps-migrations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)