### PR TITLE
Switch from deprecated `Plek.current` to `Plek.new`.

### DIFF
--- a/app/zendesk_tickets/problem_report.erb
+++ b/app/zendesk_tickets/problem_report.erb
@@ -1,4 +1,4 @@
-url: <%= Plek.current.website_root %><%= @contact.path %>
+url: <%= Plek.new.website_root %><%= @contact.path %>
 what_doing: <%= @contact.what_doing || "-" %>
 what_wrong: <%= @contact.what_wrong || "-" %>
 user_agent: <%= @contact.user_agent || "unknown" %>

--- a/lib/zendesk/problem_report_ticket.rb
+++ b/lib/zendesk/problem_report_ticket.rb
@@ -40,7 +40,7 @@ module Zendesk
     end
 
     def govuk_host
-      Plek.current.website_uri.host # www.gov.uk or www.preview.alphagov.co.uk
+      Plek.new.website_uri.host # www.gov.uk or www.preview.alphagov.co.uk
     end
   end
 end


### PR DESCRIPTION
This just gets rid of the deprecation warnings in the logs. No functional change.