### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "gds_zendesk"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "kaminari"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mlanett-redis-lock"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,7 @@ DEPENDENCIES
   govuk_sidekiq
   kaminari
   listen
+  mail (~> 2.7.1)
   mail-notify
   mlanett-redis-lock
   pg


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
