### PR TITLE
Ignore Ruby 2.7.6 EOL Brakeman warning

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 291,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "4850ceb993b6f05ea62bc58350d338c34e20990f4d3ee5934bca2e614cdecc57",
@@ -18,6 +37,9 @@
       },
       "user_input": "Rails.env",
       "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
       "note": "This is not a SQL injection because no user input is used at any point."
     },
     {
@@ -38,6 +60,9 @@
       },
       "user_input": "last_7_days",
       "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
       "note": "No user data."
     },
     {
@@ -58,9 +83,12 @@
       },
       "user_input": "last_7_days",
       "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
       "note": "No user data."
     }
   ],
-  "updated": "2022-10-06 11:38:00 +0100",
-  "brakeman_version": "5.2.3"
+  "updated": "2023-02-20 10:34:56 +0000",
+  "brakeman_version": "5.4.0"
 }


### PR DESCRIPTION
It's not yet at EOL and work is currently on-going to upgrade the Ruby version. This warning is blocking CI for other changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
