### PR TITLE
Allow AWS auth methods other than secret key to work.

### DIFF
--- a/lib/s3_file_uploader.rb
+++ b/lib/s3_file_uploader.rb
@@ -12,8 +12,9 @@ class S3FileUploader
     @connection ||= Fog::Storage.new(
       provider: "AWS",
       region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"] || "",
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"] || "",
+      use_iam_profile: !ENV["AWS_ACCESS_KEY_ID"],
     )
   end
 end


### PR DESCRIPTION
This lets us stop using long-lived credentials, for example by switching to EC2 instance profile creds or pod identity (IRSA in Amazon parlance).

The Fog library kinda reinvents the wheel when it comes to AWS SDK authentication, hence we have to set use_iam_profile ourselves according to whether we're passing an access key. `aws_access_key_id` and `aws_secret_access_key` are required args, even when `use_iam_profile` is true.