### PR TITLE
Remove original lock now a safe time has passed

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,29 +3,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "4850ceb993b6f05ea62bc58350d338c34e20990f4d3ee5934bca2e614cdecc57",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/distributed_lock.rb",
-      "line": 12,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.new.lock(\"support-api:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "DistributedLock",
-        "method": "lock"
-      },
-      "user_input": "Rails.env",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": "This is not a SQL injection because no user input is used at any point."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "7b165725021184fddd47bbf499b7da4f91a2472e4a4248bb543f9646a8d5ea35",
       "check_name": "SQL",
       "message": "Possible SQL injection",

--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -5,18 +5,15 @@ class DistributedLock
   LIFETIME = (10 * 60) # seconds
 
   def initialize(lock_name)
-    @lock_name = lock_name
     @full_lock_name = ActiveRecord::Base.sanitize_sql("support-api:#{lock_name}")
   end
 
   def lock
-    Redis.new.lock("support-api:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
-      Redis.new.lock(@full_lock_name, life: LIFETIME) do
-        Rails.logger.debug("Successfully got a lock. Running...")
-        yield
-      end
+    Redis.new.lock(@full_lock_name, life: LIFETIME) do
+      Rails.logger.debug("Successfully got a lock. Running...")
+      yield
     end
   rescue Redis::Lock::LockNotAcquired => e
-    Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
+    Rails.logger.debug("Failed to get lock for #{@full_lock_name} (#{e.message}). Another process probably got there first.")
   end
 end


### PR DESCRIPTION
Removes the original lock, moving us to the simplified lock name added here: https://github.com/alphagov/support-api/pull/778

Can be merged once a safe period of time has passed (min 24 hours after original pull merged, so Thu May 18th would be reasonable)

https://trello.com/c/84yWQ0NJ/1662-ps-15-clean-up-brakeman-errors-following-on-from-rediscurrent-redisnew-updates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
