### PR TITLE
Add sentry-sidekiq to track Sidekiq errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "mail-notify"
 gem "mlanett-redis-lock"
 gem "pg"
 gem "plek"
+gem "sentry-sidekiq"
 gem "user_agent_parser"
 gem "whenever", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,9 @@ GEM
       sentry-ruby (~> 5.9.0)
     sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.9.0)
+      sentry-ruby (~> 5.9.0)
+      sidekiq (>= 3.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.5)
@@ -469,6 +472,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rubocop-govuk
+  sentry-sidekiq
   shoulda-matchers
   simplecov
   spring


### PR DESCRIPTION
The default configuration comes from GovukError in https://github.com/alphagov/govuk_app_config

Added in response to:

```
Warning: GovukError is not configured to track Sidekiq errors,
install the sentry-sidekiq gem to track them.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
