### PR TITLE
Increase feedback duplicate detector interval range 

### DIFF
--- a/lib/duplicate_detector.rb
+++ b/lib/duplicate_detector.rb
@@ -25,7 +25,7 @@ private
 end
 
 class AnonymousFeedbackComparator
-  DUPLICATION_INTERVAL_IN_SECONDS = 5
+  DUPLICATION_INTERVAL_IN_SECONDS = 300
 
   def initialize(fields_to_compare)
     @fields_to_compare = fields_to_compare

--- a/spec/models/duplicate_detector_spec.rb
+++ b/spec/models/duplicate_detector_spec.rb
@@ -22,7 +22,7 @@ describe DuplicateDetector do
     let(:r1) { { "a" => "b", "created_at" => current_time } }
     let(:r2) { r1.clone }
     let(:r3) { { "a" => "b", "created_at" => current_time + 4 } }
-    let(:r4) { { "a" => "b", "created_at" => current_time + 8 } }
+    let(:r4) { { "a" => "b", "created_at" => current_time + 300 } }
 
     it "detects if two identical pieces of feedback are created within a short time of each other" do
       expect(comparator.same?(r1, r2)).to be_truthy


### PR DESCRIPTION
User's of the Feedback Explorer service are finding it time
consuming to manually remove duplicate entries in the CSV export
they generate for 23 services each month (e.g. /done/view-driving-licence).

The rake task `anonymous_feedback_deduplication:recent` is scheduled
to run every 5 minutes to process any duplicates found. It's currently
removing records being created multiple times within a 5 second period.
This is a known long term issue and was originally introduced in
https://github.com/alphagov/support/pull/144

Most of the duplicate records reported are generated within 5 minutes
of each other. From inspecting the data we suspect it's from people
clicking the submit button twice, or hit the back button after submitting.
Increasing the interval range should significantly reduce the number
of duplicate entries found in the CSV.

Trello card: https://trello.com/c/IuYExUWI/3414-investigate-duplicate-data-in-csv-files-from-feedback-explorer-support-app
