### PR TITLE
Allow any app to create support tickets

### DIFF
--- a/app/controllers/support_tickets_controller.rb
+++ b/app/controllers/support_tickets_controller.rb
@@ -1,0 +1,19 @@
+class SupportTicketsController < ApplicationController
+  def create
+    support_ticket = SupportTicket.new(attributes)
+
+    if support_ticket.valid?
+      GDS_ZENDESK_CLIENT.ticket.create!(support_ticket.attributes)
+
+      render json: { status: "success" }, status: :created
+    else
+      render json: { status: "error", errors: support_ticket.errors }, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def attributes
+    params.slice(:subject, :tags, :user_agent, :description)
+  end
+end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -1,0 +1,34 @@
+class SupportTicket
+  include ActiveModel::Validations
+
+  validates :subject, :description, presence: true
+
+  def initialize(attributes)
+    @subject = attributes.fetch(:subject, nil)
+    @tags = attributes.fetch(:tags, nil)
+    @user_agent = attributes.fetch(:user_agent, nil)
+    @description = attributes.fetch(:description, nil)
+  end
+
+  def attributes
+    {
+      "subject" => subject,
+      "tags" => tags,
+      "body" => ticket_body,
+    }
+  end
+
+private
+
+  attr_reader :subject, :tags, :user_agent, :description
+
+  def ticket_body
+    <<-TICKET_BODY.strip_heredoc
+      [User agent]
+      #{user_agent}
+
+      [Details]
+      #{description}
+    TICKET_BODY
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,11 @@ Rails.application.routes.draw do
             format: false,
             param: :slug
 
+  resources "support-tickets",
+            only: :create,
+            controller: "support_tickets",
+            as: "support_ticket"
+
   get "/feedback-by-day/:date", to: "feedback_by_day#index", format: false
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe SupportTicket, "validations" do
+  it "validates presence of subject" do
+    support_ticket = described_class.new({})
+    support_ticket.valid?
+
+    expect(support_ticket.errors.messages.to_h).to include(subject: include("can't be blank"))
+  end
+
+  it "validates presence of description" do
+    support_ticket = described_class.new({})
+    support_ticket.valid?
+
+    expect(support_ticket.errors.messages.to_h).to include(description: include("can't be blank"))
+  end
+end
+
+describe SupportTicket, "#attributes" do
+  it "generates a hash of attributes to create a Zendesk ticket" do
+    support_ticket = described_class.new(
+      subject: "Feedback for app",
+      tags: %w[app_name],
+      user_agent: "Safari",
+      description: "Ticket details go here.",
+    )
+
+    expect(support_ticket.attributes).to eq(
+      "subject" => "Feedback for app",
+      "tags" => %w[app_name],
+      "body" => <<-TICKET_BODY.strip_heredoc,
+                  [User agent]
+                  Safari
+
+                  [Details]
+                  Ticket details go here.
+      TICKET_BODY
+    )
+  end
+
+  it "generates a hash of attributes where the body omits the optional user agent" do
+    support_ticket = described_class.new(
+      subject: "Feedback for app",
+      tags: %w[app_name],
+      description: "Ticket details go here.",
+    )
+
+    expect(support_ticket.attributes).to eq(
+      "subject" => "Feedback for app",
+      "tags" => %w[app_name],
+      "body" => <<-TICKET_BODY.strip_heredoc,
+                  [User agent]
+
+
+                  [Details]
+                  Ticket details go here.
+      TICKET_BODY
+    )
+  end
+end

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+describe "Support Tickets" do
+  it "responds succesfully" do
+    stub_zendesk_ticket_creation
+
+    post "/support-tickets",
+         params: {
+           subject: "Feedback for app",
+           tags: %w[app_name],
+           user_agent: "Safari",
+           description: "Ticket details go here.",
+         }
+
+    expect(response.code).to eq("201")
+    expect(response_hash).to include("status" => "success")
+  end
+
+  it "sends the feedback to Zendesk" do
+    zendesk_request = expect_zendesk_to_receive_ticket(
+      "subject" => "Feedback for app",
+      "tags" => %w[app_name],
+      "body" => <<-TICKET_BODY.strip_heredoc,
+                 [User agent]
+                 Safari
+
+                 [Details]
+                 Ticket details go here.
+      TICKET_BODY
+    )
+
+    post "/support-tickets",
+         params: {
+           subject: "Feedback for app",
+           tags: %w[app_name],
+           user_agent: "Safari",
+           description: "Ticket details go here.",
+         }
+
+    expect(zendesk_request).to have_been_made
+  end
+
+  it "responds unsuccessfully if the feedback isn't valid" do
+    post "/support-tickets",
+         params: { subject: "Feedback for app" }
+
+    expect(response.code).to eq("422")
+    expect(response_hash).to include("status" => "error")
+  end
+
+  it "returns error if the subject field is empty" do
+    post "/support-tickets",
+         params: { description: "Ticket details go here." }
+
+    expect(response_hash).to include("errors" => include("subject" => include("can't be blank")))
+  end
+
+  it "returns error if the description field is empty" do
+    post "/support-tickets",
+         params: { subject: "Feedback for app" }
+
+    expect(response_hash).to include("errors" => include("description" => include("can't be blank")))
+  end
+
+  def response_hash
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
We want to make it easy for any app to create a support ticket and support-api feels like the best place for this.

The endpoint `/support-tickets` will be made available to apps via [gds-api-adapters](https://github.com/alphagov/gds-api-adapters), which allows them to pass Zendesk ticket parameters to support-api.

The [gds_zendesk](https://github.com/alphagov/gds_zendesk) gem provides a client to communicate with Zendesk and it has a `ticket.create!` method, which is called if the parameters provided are valid.

The only required standard ticket fields are `subject` and `description` - for more information see https://support.zendesk.com/hc/en-us/articles/4408886739098-About-ticket-fields

This provides the basis of creating Zendesk tickets and will need adjustments once we know what other information is required for different types of support tickets.

We should keep the naming convention generic, as there is a high possibility that we move away from Zendesk in the future.

Related PR: https://github.com/alphagov/gds-api-adapters/pull/1271

Trello card: https://trello.com/c/dPTgPUok/3495-add-raise-zendesk-ticket-feature-to-support-api-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
