### PR TITLE
Add GitHub Action workflow for verifying pact tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,9 @@ jobs:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
         run: bundle exec rake spec
+
+  pact-tests:
+    name: Run Pact tests
+    uses: ./.github/workflows/pact-verify.yml
+    with:
+      ref: ${{ github.ref }}

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,0 +1,71 @@
+# Pact verify workflow
+#
+# This workflow asserts that Pact contract tests are valid against this
+# codebase. It is trigged when changes are made to this project and it
+# is explicitly called by GDS API Adapters when changes are made there.
+
+name: Run Pact tests
+
+on:
+  workflow_call:
+    inputs:
+      # The commit / tag of this repo to test against
+      ref:
+        required: false
+        type: string
+        default: main
+      # A GitHub Action artifact which contains the pact definition files
+      # Support API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
+        type: string
+      # When using an artifact this is the file path to the pact that is verified
+      # against
+      pact_artifact_file_to_verify:
+        required: false
+        type: string
+        default: gds_api_adapters-support_api.json
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
+      pact_consumer_version:
+        required: false
+        type: string
+        default: branch-main
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgresql://postgres@localhost/test-db
+      RAILS_ENV: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: alphagov/support-api
+          ref: ${{ inputs.ref }}
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rails db:setup
+      - if: inputs.pact_artifact == ''
+        run: bundle exec rake pact:verify
+        env:
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+      - if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+      - if: inputs.pact_artifact != ''
+        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -33,13 +33,7 @@ end
 Pact.provider_states_for "GDS API Adapters" do
   provider_state "the parameters are valid" do
     set_up do
-      params = {
-        subject: "Feedback for app",
-        tags: %w[app_name],
-        user_agent: "Safari",
-        description: "There is something wrong with this page.",
-      }
-      SupportTicket.new(params)
+      stub_request(:post, "https://govuk.zendesk.com/api/v2/tickets").to_return(status: 210, body: { "status" => "success" }.to_json, headers: { "Content-Type" => "application/json" })
     end
   end
 


### PR DESCRIPTION
This workflow will verify via the deployment pipeline that each new build of support-api honours it's contract tests with gds-api-adapters.

Related PRS:

- https://github.com/alphagov/gds-api-adapters/pull/1273
- https://github.com/alphagov/support-api/pull/964

Trello card: https://trello.com/c/QBYirV6S/3494-add-pact-test-for-create-support-tickets-endpoint-5

