### PR TITLE
Fix Pact verify workflow

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -68,4 +68,4 @@ jobs:
           name: ${{ inputs.pact_artifact }}
           path: tmp/pacts
       - if: inputs.pact_artifact != ''
-        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}
+        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]


### PR DESCRIPTION
Closing brackets was missing resulting in `Don't know how to build task 'pact:verify:at[tmp/pacts/gds_api_adapters-support_api.json'` error in gds-api-adapters.

See failing CI:
- https://github.com/alphagov/gds-api-adapters/actions/runs/9566384476/job/26371607850?pr=1274
- https://github.com/alphagov/gds-api-adapters/actions/runs/9566383671/job/26371597965?pr=1274

[Trello](https://trello.com/c/QBYirV6S/3494-add-pact-test-for-create-support-tickets-endpoint-5)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
