### PR TITLE
Update support tickets endpoint part1

### DIFF
--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -14,7 +14,9 @@ class SupportTicket
     {
       "subject" => subject,
       "tags" => tags,
-      "body" => ticket_body,
+      "comment" => {
+        "body" => description,
+      },
     }
   end
 

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -6,7 +6,6 @@ class SupportTicket
   def initialize(attributes)
     @subject = attributes.fetch(:subject, nil)
     @tags = attributes.fetch(:tags, nil)
-    @user_agent = attributes.fetch(:user_agent, nil)
     @description = attributes.fetch(:description, nil)
   end
 
@@ -22,15 +21,5 @@ class SupportTicket
 
 private
 
-  attr_reader :subject, :tags, :user_agent, :description
-
-  def ticket_body
-    <<-TICKET_BODY.strip_heredoc
-      [User agent]
-      #{user_agent}
-
-      [Details]
-      #{description}
-    TICKET_BODY
-  end
+  attr_reader :subject, :tags, :description
 end

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -28,13 +28,9 @@ describe SupportTicket, "#attributes" do
     expect(support_ticket.attributes).to eq(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
-      "body" => <<-TICKET_BODY.strip_heredoc,
-                  [User agent]
-                  Safari
-
-                  [Details]
-                  Ticket details go here.
-      TICKET_BODY
+      "comment" => {
+        "body" => "Ticket details go here.",
+      },
     )
   end
 
@@ -48,13 +44,9 @@ describe SupportTicket, "#attributes" do
     expect(support_ticket.attributes).to eq(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
-      "body" => <<-TICKET_BODY.strip_heredoc,
-                  [User agent]
-
-
-                  [Details]
-                  Ticket details go here.
-      TICKET_BODY
+      "comment" => {
+        "body" => "Ticket details go here.",
+      },
     )
   end
 end

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -21,7 +21,6 @@ describe SupportTicket, "#attributes" do
     support_ticket = described_class.new(
       subject: "Feedback for app",
       tags: %w[app_name],
-      user_agent: "Safari",
       description: "Ticket details go here.",
     )
 

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -8,7 +8,6 @@ describe "Support Tickets" do
          params: {
            subject: "Feedback for app",
            tags: %w[app_name],
-           user_agent: "Safari",
            description: "Ticket details go here.",
          }
 
@@ -29,7 +28,6 @@ describe "Support Tickets" do
          params: {
            subject: "Feedback for app",
            tags: %w[app_name],
-           user_agent: "Safari",
            description: "Ticket details go here.",
          }
 

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -20,13 +20,9 @@ describe "Support Tickets" do
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
-      "body" => <<-TICKET_BODY.strip_heredoc,
-                 [User agent]
-                 Safari
-
-                 [Details]
-                 Ticket details go here.
-      TICKET_BODY
+      "comment" => {
+        "body" => "Ticket details go here.",
+      },
     )
 
     post "/support-tickets",


### PR DESCRIPTION
- Use the comment property to set the Zendesk ticket description
- Don't format ticket body in SupportTicket as those will be coming in formatted
- Remove `user_agent`, if necessary it will be in the body

See commit messages for details. Tested in integration. This endpoint is not currently used.

Zendesk API reference: https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
