### PR TITLE
Update create support ticket endpoint

### DIFF
--- a/app/controllers/support_tickets_controller.rb
+++ b/app/controllers/support_tickets_controller.rb
@@ -14,6 +14,14 @@ class SupportTicketsController < ApplicationController
 private
 
   def support_ticket_attributes
-    params.slice(:subject, :tags, :user_agent, :description)
+    params.slice(
+      :subject, :description, :priority, :requester, :collaborators, :tags, :custom_fields, :ticket_form_id
+    ).permit(
+      :subject, :description, :priority, :ticket_form_id,
+      requester: %i[locale_id email name],
+      collaborators: [],
+      tags: [],
+      custom_fields: %i[id value]
+    )
   end
 end

--- a/app/controllers/support_tickets_controller.rb
+++ b/app/controllers/support_tickets_controller.rb
@@ -1,9 +1,9 @@
 class SupportTicketsController < ApplicationController
   def create
-    support_ticket = SupportTicket.new(attributes)
+    support_ticket = SupportTicket.new(support_ticket_attributes)
 
     if support_ticket.valid?
-      GDS_ZENDESK_CLIENT.ticket.create!(support_ticket.attributes)
+      GDS_ZENDESK_CLIENT.ticket.create!(support_ticket.zendesk_ticket_attributes)
 
       render json: { status: "success" }, status: :created
     else
@@ -13,7 +13,7 @@ class SupportTicketsController < ApplicationController
 
 private
 
-  def attributes
+  def support_ticket_attributes
     params.slice(:subject, :tags, :user_agent, :description)
   end
 end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -5,19 +5,29 @@ class SupportTicket
 
   def initialize(attributes)
     @subject = attributes.fetch(:subject, nil)
-    @tags = attributes.fetch(:tags, nil)
     @description = attributes.fetch(:description, nil)
+    @priority = attributes.fetch(:priority, nil)
+    @requester = attributes.fetch(:requester, nil)
+    @collaborators = attributes.fetch(:collaborators, nil)
+    @tags = attributes.fetch(:tags, nil)
+    @custom_fields = attributes.fetch(:custom_fields, nil)
+    @ticket_form_id = attributes.fetch(:ticket_form_id, nil)
   end
 
   def zendesk_ticket_attributes
     {
       "subject" => subject,
       "comment" => { "body" => description },
+      "priority" => priority,
+      "requester" => requester,
+      "collaborators" => collaborators,
       "tags" => tags,
+      "custom_fields" => custom_fields,
+      "ticket_form_id" => ticket_form_id,
     }.compact
   end
 
 private
 
-  attr_reader :subject, :tags, :description
+  attr_reader :subject, :description, :priority, :requester, :collaborators, :tags, :custom_fields, :ticket_form_id
 end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -9,7 +9,7 @@ class SupportTicket
     @description = attributes.fetch(:description, nil)
   end
 
-  def attributes
+  def zendesk_ticket_attributes
     {
       "subject" => subject,
       "tags" => tags,

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -12,11 +12,9 @@ class SupportTicket
   def zendesk_ticket_attributes
     {
       "subject" => subject,
+      "comment" => { "body" => description },
       "tags" => tags,
-      "comment" => {
-        "body" => description,
-      },
-    }
+    }.compact
   end
 
 private

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -16,7 +16,7 @@ describe SupportTicket, "validations" do
   end
 end
 
-describe SupportTicket, "#attributes" do
+describe SupportTicket, "#zendesk_ticket_attributes" do
   it "generates a hash of attributes to create a Zendesk ticket" do
     support_ticket = described_class.new(
       subject: "Feedback for app",
@@ -24,7 +24,7 @@ describe SupportTicket, "#attributes" do
       description: "Ticket details go here.",
     )
 
-    expect(support_ticket.attributes).to eq(
+    expect(support_ticket.zendesk_ticket_attributes).to eq(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
       "comment" => {
@@ -40,7 +40,7 @@ describe SupportTicket, "#attributes" do
       description: "Ticket details go here.",
     )
 
-    expect(support_ticket.attributes).to eq(
+    expect(support_ticket.zendesk_ticket_attributes).to eq(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
       "comment" => {

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -33,16 +33,14 @@ describe SupportTicket, "#zendesk_ticket_attributes" do
     )
   end
 
-  it "generates a hash of attributes where the body omits the optional user agent" do
+  it "generates a hash of attributes and omits the optional attributes if value was not provided" do
     support_ticket = described_class.new(
       subject: "Feedback for app",
-      tags: %w[app_name],
       description: "Ticket details go here.",
     )
 
     expect(support_ticket.zendesk_ticket_attributes).to eq(
       "subject" => "Feedback for app",
-      "tags" => %w[app_name],
       "comment" => {
         "body" => "Ticket details go here.",
       },

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -20,16 +20,32 @@ describe SupportTicket, "#zendesk_ticket_attributes" do
   it "generates a hash of attributes to create a Zendesk ticket" do
     support_ticket = described_class.new(
       subject: "Feedback for app",
-      tags: %w[app_name],
       description: "Ticket details go here.",
+      priority: "normal",
+      requester: { "locale_id" => 1, "email" => "someone@exampe.com", "name" => "Some user" },
+      collaborators: %w[a@b.com c@d.com],
+      tags: %w[app_name],
+      custom_fields: [
+        { "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
+        { "id" => 7_949_106_580_380, "value" => "cr_benefits" },
+      ],
+      ticket_form_id: 123,
     )
 
     expect(support_ticket.zendesk_ticket_attributes).to eq(
       "subject" => "Feedback for app",
-      "tags" => %w[app_name],
       "comment" => {
         "body" => "Ticket details go here.",
       },
+      "priority" => "normal",
+      "requester" => { "locale_id" => 1, "email" => "someone@exampe.com", "name" => "Some user" },
+      "collaborators" => %w[a@b.com c@d.com],
+      "tags" => %w[app_name],
+      "custom_fields" => [
+        { "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
+        { "id" => 7_949_106_580_380, "value" => "cr_benefits" },
+      ],
+      "ticket_form_id" => 123,
     )
   end
 

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -9,6 +9,14 @@ describe "Support Tickets" do
            subject: "Feedback for app",
            tags: %w[app_name],
            description: "Ticket details go here.",
+           priority: "normal",
+           requester: { locale_id: 1, email: "someone@exampe.com", name: "Some user" },
+           collaborators: %w[a@b.com c@d.com],
+           custom_fields: [
+             { id: 7_948_652_819_356, value: "cr_inaccuracy" },
+             { id: 7_949_106_580_380, value: "cr_benefits" },
+           ],
+           ticket_form_id: 123,
          }
 
     expect(response.code).to eq("201")
@@ -28,13 +36,14 @@ describe "Support Tickets" do
          params: {
            subject: "Feedback for app",
            tags: %w[app_name],
+           requester: { locale_id: 1, email: "someone@exampe.com", name: "Some user" },
            description: "Ticket details go here.",
          }
 
     expect(zendesk_request).to have_been_made
   end
 
-  it "responds unsuccessfully if the feedback isn't valid" do
+  it "responds unsuccessfully if the support ticket isn't valid" do
     post "/support-tickets",
          params: { subject: "Feedback for app" }
 


### PR DESCRIPTION
### What

Add additional Zendesk ticket attributes:

- priority
- requester
- collaborators
- custom_fields
- ticket_form_id

### Why

Those are required by apps that create Zendesk tickets:
- https://github.com/alphagov/support/blob/main/app/models/zendesk/zendesk_tickets.rb
- https://github.com/alphagov/smart-answers/blob/main/lib/support_ticket.rb
- https://github.com/alphagov/feedback/blob/main/app/lib/support_ticket_creator.rb

### Testing

Tested in integration with the most complex [ticket](https://govuk.zendesk.com/agent/tickets/5894126).

https://github.com/alphagov/support/issues/1422

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
