### PR TITLE
Check if requester is suspended before creating Zendesk ticket

### DIFF
--- a/spec/helpers/zendesk_test_helpers.rb
+++ b/spec/helpers/zendesk_test_helpers.rb
@@ -20,6 +20,24 @@ module Zendesk
       stub_zendesk_ticket_creation_with_body("ticket" => hash_including(opts))
     end
 
+    def zendesk_has_no_user_with_email(email)
+      stub_request(:get, "#{zendesk_endpoint}/users/search?query=#{email}")
+        .to_return(body: { users: [], previous_page: nil, next_page: nil, count: 0 }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+    end
+
+    def zendesk_has_suspended_user_with_email(email)
+      stub_request(:get, "#{zendesk_endpoint}/users/search?query=#{email}")
+        .to_return(body: { users: [{ email:, suspended: true }] }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+    end
+
+    def zendesk_has_valid_user_with_email(email)
+      stub_request(:get, "#{zendesk_endpoint}/users/search?query=#{email}")
+        .to_return(body: { users: [{ email:, suspended: false }] }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+    end
+
     def zendesk_endpoint
       "https://govuk.zendesk.com/api/v2"
     end

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 describe SupportTicket, "validations" do
+  let(:required_atrributes) do
+    {
+      subject: "Feedback for app",
+      description: "Ticket details go here.",
+    }
+  end
+
   it "validates presence of subject" do
     support_ticket = described_class.new({})
     support_ticket.valid?
@@ -14,6 +21,59 @@ describe SupportTicket, "validations" do
 
     expect(support_ticket.errors.messages.to_h).to include(description: include("can't be blank"))
   end
+
+  describe "#requester_not_suspended validation" do
+    it "is invalid if requester is suspended in Zendesk" do
+      zendesk_has_suspended_user_with_email("suspended-user@example.com")
+
+      support_ticket = described_class.new(
+        required_atrributes.merge(
+          requester: { "locale_id" => 1, email: "suspended-user@example.com", "name" => "Naughtly user" },
+        ),
+      )
+      support_ticket.valid?
+
+      expect(support_ticket.errors.messages.to_h).to include(requester: include("is suspended in Zendesk"))
+    end
+
+    it "is valid if requester is not suspended in Zendesk" do
+      zendesk_has_valid_user_with_email("ok-user@example.com")
+
+      support_ticket = described_class.new(
+        required_atrributes.merge(
+          { requester: { email: "ok-user@example.com" } },
+        ),
+      )
+      expect(support_ticket.valid?).to eq(true)
+    end
+
+    it "is valid if Zendesk doesn't have user with this email address" do
+      zendesk_has_no_user_with_email("user@example.com")
+
+      support_ticket = described_class.new(
+        required_atrributes.merge(
+          { requester: { "email" => "user@example.com", "name" => "User" } },
+        ),
+      )
+
+      expect(support_ticket.valid?).to eq(true)
+    end
+
+    it "doesn't validate if requester attribute is not provided" do
+      support_ticket = described_class.new(required_atrributes)
+
+      expect(support_ticket.valid?).to eq(true)
+    end
+
+    it "doesn't validate if requester email attribute is not provided" do
+      support_ticket = described_class.new(
+        required_atrributes.merge(
+          { requester: { "name" => "Some app" } },
+        ),
+      )
+      expect(support_ticket.valid?).to eq(true)
+    end
+  end
 end
 
 describe SupportTicket, "#zendesk_ticket_attributes" do
@@ -22,7 +82,7 @@ describe SupportTicket, "#zendesk_ticket_attributes" do
       subject: "Feedback for app",
       description: "Ticket details go here.",
       priority: "normal",
-      requester: { "locale_id" => 1, "email" => "someone@exampe.com", "name" => "Some user" },
+      requester: { "locale_id" => 1, "email" => "someone@example.com", "name" => "Some user" },
       collaborators: %w[a@b.com c@d.com],
       tags: %w[app_name],
       custom_fields: [
@@ -38,7 +98,7 @@ describe SupportTicket, "#zendesk_ticket_attributes" do
         "body" => "Ticket details go here.",
       },
       "priority" => "normal",
-      "requester" => { "locale_id" => 1, "email" => "someone@exampe.com", "name" => "Some user" },
+      "requester" => { "locale_id" => 1, "email" => "someone@example.com", "name" => "Some user" },
       "collaborators" => %w[a@b.com c@d.com],
       "tags" => %w[app_name],
       "custom_fields" => [

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "Support Tickets" do
   it "responds succesfully" do
     stub_zendesk_ticket_creation
+    zendesk_has_valid_user_with_email("someone@example.com")
 
     post "/support-tickets",
          params: {
@@ -10,7 +11,7 @@ describe "Support Tickets" do
            tags: %w[app_name],
            description: "Ticket details go here.",
            priority: "normal",
-           requester: { locale_id: 1, email: "someone@exampe.com", name: "Some user" },
+           requester: { locale_id: 1, email: "someone@example.com", name: "Some user" },
            collaborators: %w[a@b.com c@d.com],
            custom_fields: [
              { id: 7_948_652_819_356, value: "cr_inaccuracy" },
@@ -24,6 +25,7 @@ describe "Support Tickets" do
   end
 
   it "sends the feedback to Zendesk" do
+    zendesk_has_valid_user_with_email("someone@example.com")
     zendesk_request = expect_zendesk_to_receive_ticket(
       "subject" => "Feedback for app",
       "tags" => %w[app_name],
@@ -36,7 +38,7 @@ describe "Support Tickets" do
          params: {
            subject: "Feedback for app",
            tags: %w[app_name],
-           requester: { locale_id: 1, email: "someone@exampe.com", name: "Some user" },
+           requester: { locale_id: 1, email: "someone@example.com", name: "Some user" },
            description: "Ticket details go here.",
          }
 


### PR DESCRIPTION
It's not possible to create Zendesk ticket if a requester is suspended in Zendesk. The following error is raised:
```
  ZendeskAPI::Error::RecordInvalid:
  {"requester"=>[{"description"=>"Requester: <Name> is suspended."}]}
  (ZendeskAPI::Error::RecordInvalid)
```

We don't want to rescue ZendeskAPI::Error::RecordInvalid as this error is raised for other issue such as incorrect formatting.

Suspended users can be found https://govuk.zendesk.com/agent/user_filters

### Testing
Tested in integration using Support app
```
attr = {
  :subject=>"Testing support api",
  "tags"=>["govt_form", "technical_fault", "fault_with_content_data", "govuk_platform_support", "slack_has_been_notified"],
"descreption"=>Testing. Assign to Aga Dufrat (2nd line — GOV.UK Alerts and Issues)"},
requester: { "email" => "<PPI-REDACTED>", "name" => "Some suspended user" }}

Services.support_api.raise_support_ticket(attr)


>  URL: http://support-api/support-tickets (GdsApi::HTTPUnprocessableEntity)
> Response body:
 . {"status":"error","errors":{"requester":["is suspended in Zendesk"]}}
```

Issue: https://github.com/alphagov/support/issues/1422

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
