### PR TITLE
Handle ZendeskAPI::Error::RecordInvalid errors

### DIFF
--- a/app/controllers/support_tickets_controller.rb
+++ b/app/controllers/support_tickets_controller.rb
@@ -1,4 +1,8 @@
 class SupportTicketsController < ApplicationController
+  rescue_from ZendeskAPI::Error::RecordInvalid, with: :handle_as_validation_error
+
+  rescue_from ZendeskAPI::Error::NetworkError, with: :cast_zendesk_api_error
+
   def create
     support_ticket = SupportTicket.new(support_ticket_attributes)
 
@@ -12,6 +16,14 @@ class SupportTicketsController < ApplicationController
   end
 
 private
+
+  def handle_as_validation_error(error)
+    render json: { status: "error", errors: error.message }, status: :unprocessable_entity
+  end
+
+  def cast_zendesk_api_error(error)
+    render json: { status: "error", errors: error.message }, status: error.response[:status]
+  end
 
   def support_ticket_attributes
     params.slice(

--- a/spec/helpers/zendesk_test_helpers.rb
+++ b/spec/helpers/zendesk_test_helpers.rb
@@ -38,6 +38,14 @@ module Zendesk
                    headers: { "Content-Type" => "application/json" })
     end
 
+    def stub_zendesk_returns_record_invalid
+      stub_request(:any, /#{zendesk_endpoint}\/.*/).to_return(status: 422)
+    end
+
+    def stub_zendesk_is_unavailable
+      stub_request(:any, /#{zendesk_endpoint}\/.*/).to_return(status: 503)
+    end
+
     def zendesk_endpoint
       "https://govuk.zendesk.com/api/v2"
     end

--- a/spec/requests/support_tickets_spec.rb
+++ b/spec/requests/support_tickets_spec.rb
@@ -67,6 +67,32 @@ describe "Support Tickets" do
     expect(response_hash).to include("errors" => include("description" => include("can't be blank")))
   end
 
+  it "sends validation error response if ZendeskAPI::Error::RecordInvalid occurs" do
+    stub_zendesk_returns_record_invalid
+    post "/support-tickets",
+         params: {
+           subject: "Feedback for app",
+           description: "Ticket body",
+           requester: { email: "a@b.com" },
+         }
+
+    expect(response.code).to eq("422")
+    expect(response_hash).to include("status" => "error")
+  end
+
+  it "casts the error responses if ZendeskAPI::Error::NetworkError occurs" do
+    stub_zendesk_is_unavailable
+
+    post "/support-tickets",
+         params: {
+           subject: "Feedback for app",
+           description: "Ticket body",
+         }
+
+    expect(response.code).to eq("503")
+    expect(response_hash).to include("status" => "error")
+  end
+
   def response_hash
     JSON.parse(response.body)
   end


### PR DESCRIPTION
Otherwise 500 error is returned. The Client apps can then handle those appropriately.

Ideally calling Zendesk API should be done in a worker that would handle all possible Zendesk API errors with appropriate retry logic (e.g. don’t retry on 409 :conflict). The controller should respond with 202 :accepted status rather than 201 :created.
It is not implemented at this time due to change in delivery priorities (and this work being reprioritised).

https://github.com/alphagov/support/issues/1422

--- 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
