### PR TITLE
Remove git source from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
-
 gem "rails", "7.2.2"
 
 gem "aws-sdk-s3"


### PR DESCRIPTION
This was added in f9a5adfc68b173dcbf229e342470bd0930583ec0, presumably so it could be used in 38721ae0d277d4a0f7160213cf9ded6decb04037. However this was removed in dce718f019bbde308dfcafe2de3d9da9d48e8a95.

None of the remaining gems reference a git repo, so there is no need to include the git source in the Gemfile.