### PR TITLE
Add GitHub Actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
We are using some outdated versions of GitHub Action dependencies, which is causing `actionlint` to fail on the main branch.

Adding GitHub Actions to dependabot to automatically upgrade those dependencies, so the linting checks will pass.