### PR TITLE
Do not report team only requests to Sentry in integration and staging

### DIFF
--- a/app/sidekiq/generate_feedback_csv_job.rb
+++ b/app/sidekiq/generate_feedback_csv_job.rb
@@ -20,7 +20,11 @@ class GenerateFeedbackCsvJob
 
     feedback_export_request.touch(:generated_at)
 
-    ExportNotification.notification_email(feedback_export_request.notification_email, feedback_export_request.url).deliver_now
+    begin
+      ExportNotification.notification_email(feedback_export_request.notification_email, feedback_export_request.url).deliver_now
+    rescue Notifications::Client::BadRequestError => e
+      raise if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/ || e.message !~ /team-only API key/
+    end
   end
 end
 

--- a/app/sidekiq/generate_global_export_csv_job.rb
+++ b/app/sidekiq/generate_global_export_csv_job.rb
@@ -23,7 +23,11 @@ class GenerateGlobalExportCsvJob
     feedback_export_request.save!
     feedback_export_request.touch(:generated_at)
 
-    GlobalExportNotification.notification_email(export_params["notification_email"], feedback_export_request.url).deliver_now
+    begin
+      GlobalExportNotification.notification_email(export_params["notification_email"], feedback_export_request.url).deliver_now
+    rescue Notifications::Client::BadRequestError => e
+      raise if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/ || e.message !~ /team-only API key/
+    end
   end
 end
 

--- a/spec/sidekiq/generate_global_export_csv_job_spec.rb
+++ b/spec/sidekiq/generate_global_export_csv_job_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 require "date"
+require "ostruct"
 
 describe GenerateGlobalExportCsvJob, type: :worker do
   let(:uploader) { instance_double(S3FileUploader) }
   subject(:worker) { described_class.new(uploader:) }
+  let(:from_date) { "2019-01-01" }
+  let(:to_date) { "2019-12-31" }
+  let(:notification_email) { "inside-government@digital.cabinet-office.gov.uk" }
+  let(:file_url) { %r{^http://support\.dev\.gov\.uk/anonymous_feedback/export_requests/\d+$} }
 
   before do
     expect(uploader).to receive(:save_file_to_s3)
@@ -13,17 +18,56 @@ describe GenerateGlobalExportCsvJob, type: :worker do
     mailer = double
     allow(mailer).to receive(:deliver_now)
 
-    from_date = "2019-01-01"
-    to_date = "2019-12-31"
-    notification_email = "inside-government@digital.cabinet-office.gov.uk"
-    file_url = %r{^http://support.dev.gov.uk/anonymous_feedback/export_requests/\d+$}
-
     expect(GlobalExportNotification).to receive(:notification_email).with(notification_email, file_url).and_return(mailer)
 
     subject.perform(
       "from_date" => from_date,
       "to_date" => to_date,
-      "notification_email" => "inside-government@digital.cabinet-office.gov.uk",
+      "notification_email" => notification_email,
     )
+  end
+
+  context "when Notifications::Client::BadRequestError is raised" do
+    before do
+      allow(GlobalExportNotification).to receive(:notification_email).with(any_args) do
+        raise Notifications::Client::BadRequestError, OpenStruct.new(code: 400, body: "Can't send to this recipient using a team-only API key")
+      end
+    end
+
+    it "does not raise exception in integration" do
+      ClimateControl.modify(SENTRY_CURRENT_ENV: "integration") do
+        expect {
+          subject.perform(
+            "from_date" => from_date,
+            "to_date" => to_date,
+            "notification_email" => notification_email,
+          )
+        }.not_to raise_error
+      end
+    end
+
+    it "does not raise exception in staging" do
+      ClimateControl.modify(SENTRY_CURRENT_ENV: "staging") do
+        expect {
+          subject.perform(
+            "from_date" => from_date,
+            "to_date" => to_date,
+            "notification_email" => notification_email,
+          )
+        }.not_to raise_error
+      end
+    end
+
+    it "raises exception in production" do
+      ClimateControl.modify(SENTRY_CURRENT_ENV: "production") do
+        expect {
+          subject.perform(
+            "from_date" => from_date,
+            "to_date" => to_date,
+            "notification_email" => notification_email,
+          )
+        }.to raise_error(Notifications::Client::BadRequestError)
+      end
+    end
   end
 end


### PR DESCRIPTION
We have set up our Notify accounts to not send emails in integration and staging, unless the email address is a considered a “team member”.  This is deliberate to stop users from receiving duplicated emails from production plus integration/staging.

Notify returns an error if you try to send an email address is someone who isn’t a team member:

```
Notifications::Client::BadRequestError
BadRequestError: Can't send to this recipient using a team-only API key
```

In most apps (e.g. in Whitehall and Publisher) we don’t log these to Sentry, as they serve no purpose and are not actionable.

Making the same change here, so these are no longer logged to Sentry in those environments.

[Trello card](https://trello.com/c/uber1mpV)