### PR TITLE
[PP-7236] Reject null bytes in problem reports

### DIFF
--- a/app/models/problem_report.rb
+++ b/app/models/problem_report.rb
@@ -1,8 +1,8 @@
 require "csv"
 
 class ProblemReport < AnonymousContact
-  validates :what_doing, length: { maximum: 2**16 }
-  validates :what_wrong, length: { maximum: 2**16 }
+  validates :what_doing, :what_wrong, length: { maximum: 2**16 }
+  validates :what_doing, :what_wrong, format: { without: /\x00/, message: "cannot contain null bytes" }
 
   scope :totals_for,
         lambda { |date|

--- a/spec/models/problem_report_spec.rb
+++ b/spec/models/problem_report_spec.rb
@@ -9,6 +9,9 @@ describe ProblemReport do
   it { should validate_length_of(:what_doing).is_at_most(2**16) }
   it { should validate_length_of(:what_wrong).is_at_most(2**16) }
 
+  it { should_not allow_value("\u0000").for(:what_doing) }
+  it { should_not allow_value("\u0000").for(:what_wrong) }
+
   context "#totals" do
     let(:result) do
       ProblemReport.totals_for(Time.zone.today).map { |r| { path: r.path, total: r.total } }


### PR DESCRIPTION
We are seeing bots submitting our problem report form with content that contains null bytes. This results in an exception being raise: `ArgumentError string contains null byte (ArgumentError)`.

These characters serve no purpose, so we should reject them. This will remove the Sentry alerts and stop spam that contains these characters.