### PR TITLE
[PP-7737] Fix "Total quantity by day" feature in Feedback Explorer

### DIFF
--- a/app/controllers/anonymous_feedback/global_export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/global_export_requests_controller.rb
@@ -23,10 +23,10 @@ private
 
     clean_params = params.require(:global_export_request).permit(*permitted_params).to_h
     {
-      from_date: DateParser.parse(clean_params[:from_date]),
-      to_date: DateParser.parse(clean_params[:to_date]),
-      notification_email: clean_params[:notification_email],
-      exclude_spam: clean_params[:exclude_spam],
+      "from_date" => DateParser.parse(clean_params[:from_date]).to_s,
+      "to_date" => DateParser.parse(clean_params[:to_date]).to_s,
+      "notification_email" => clean_params[:notification_email],
+      "exclude_spam" => clean_params[:exclude_spam],
     }
   end
 end

--- a/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
@@ -6,20 +6,34 @@ describe AnonymousFeedback::GlobalExportRequestsController, type: :controller do
 
     context "with valid parameters" do
       it "succeeds" do
-        expect(GenerateGlobalExportCsvJob).to receive(:perform_async).once
+        Sidekiq::Testing.fake! do
+          response = post :create,
+                          params: {
+                            global_export_request: {
+                              from_date: "2015-05-01",
+                              to_date: "2015-06-01",
+                              notification_email: "foo@example.com",
+                              exclude_spam: true,
+                            },
+                          }
 
-        response = post :create,
-                        params: {
-                          global_export_request: {
-                            from_date: "2015-05-01",
-                            to_date: "2015-06-01",
-                            notification_email: "foo@example.com",
-                            exclude_spam: true,
-                          },
-                        }
-
-        expect(response).to be_accepted
+          expect(response).to be_accepted
+        end
       end
+    end
+
+    it "queues GenerateGlobalExportCsvJob once" do
+      expect(GenerateGlobalExportCsvJob).to receive(:perform_async).once
+
+      post :create,
+           params: {
+             global_export_request: {
+               from_date: "2015-05-01",
+               to_date: "2015-06-01",
+               notification_email: "foo@example.com",
+               exclude_spam: true,
+             },
+           }
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
The feature was broken when the app upgraded to `govuk_sidekiq` version 6.0.0 in January 2023.

This is because that version switched on `strict_args` that required arguments to Sidekiq jobs to be native JSON types. However this controller was not updated to do that.

It was not caught by a test because the expectation that the `perform_async` would be called stubbed the method meaning we never checked the Sidekiq paramters were valid. Fixed the tests so this issue would be caught in the future.