### PR TITLE
Remove job/worker aliases

### DIFF
--- a/app/sidekiq/content_improvement_feedback_job.rb
+++ b/app/sidekiq/content_improvement_feedback_job.rb
@@ -5,5 +5,3 @@ class ContentImprovementFeedbackJob
     ContentImprovementFeedback.create!(feedback_params)
   end
 end
-
-ContentImprovementFeedbackWorker = ContentImprovementFeedbackJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/content_item_enrichment_job.rb
+++ b/app/sidekiq/content_item_enrichment_job.rb
@@ -25,5 +25,3 @@ private
     end
   end
 end
-
-ContentItemEnrichmentWorker = ContentItemEnrichmentJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/content_item_populate_doctype_job.rb
+++ b/app/sidekiq/content_item_populate_doctype_job.rb
@@ -17,5 +17,3 @@ class ContentItemPopulateDoctypeJob
     Rails.logger.warn "There were errors with the following paths: #{document_type_errors.join(', ')}"
   end
 end
-
-ContentItemPopulateDoctypeWorker = ContentItemPopulateDoctypeJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/generate_feedback_csv_job.rb
+++ b/app/sidekiq/generate_feedback_csv_job.rb
@@ -27,5 +27,3 @@ class GenerateFeedbackCsvJob
     end
   end
 end
-
-GenerateFeedbackCsvWorker = GenerateFeedbackCsvJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/generate_global_export_csv_job.rb
+++ b/app/sidekiq/generate_global_export_csv_job.rb
@@ -30,5 +30,3 @@ class GenerateGlobalExportCsvJob
     end
   end
 end
-
-GenerateGlobalExportCsvWorker = GenerateGlobalExportCsvJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/long_form_contact_job.rb
+++ b/app/sidekiq/long_form_contact_job.rb
@@ -6,5 +6,3 @@ class LongFormContactJob
     ZendeskTicketJob.perform_async(contact.id)
   end
 end
-
-LongFormContactWorker = LongFormContactJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/problem_report_job.rb
+++ b/app/sidekiq/problem_report_job.rb
@@ -7,5 +7,3 @@ class ProblemReportJob
     ContentItemEnrichmentJob.perform_async(problem_report.id)
   end
 end
-
-ProblemReportWorker = ProblemReportJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/service_feedback_job.rb
+++ b/app/sidekiq/service_feedback_job.rb
@@ -5,5 +5,3 @@ class ServiceFeedbackJob
     ServiceFeedback.new(service_feedback_params).save!
   end
 end
-
-ServiceFeedbackWorker = ServiceFeedbackJob ## TODO: Remove once queued jobs at the time of the upgrade are complete

--- a/app/sidekiq/zendesk_ticket_job.rb
+++ b/app/sidekiq/zendesk_ticket_job.rb
@@ -19,5 +19,3 @@ private
     end
   end
 end
-
-ZendeskTicketWorker = ZendeskTicketJob ## TODO: Remove once queued jobs at the time of the upgrade are complete


### PR DESCRIPTION
These were added in https://github.com/alphagov/support-api/pull/1044 when the workers were renamed to jobs, so the enqueued jobs would not fail when the class was renamed.

They can now be removed as all the enqueued jobs would have finished a long time ago.