### PR TITLE
Speed up AnonymousContact.summary

### DIFF
--- a/app/models/anonymous_contact.rb
+++ b/app/models/anonymous_contact.rb
@@ -70,36 +70,24 @@ class AnonymousContact < ApplicationRecord
   end
 
   def self.summary(order_by, relation: nil)
-    last_7_counts = count_in_last_n_days(7, relation:)
-    last_30_counts = count_in_last_n_days(30, relation:)
-    last_90_counts = count_in_last_n_days(90, relation:)
-
-    last_90_counts.keys.map { |path|
-      next if last_90_counts[path].zero?
-
-      {
-        path:,
-        last_7_days: last_7_counts.fetch(path, 0),
-        last_30_days: last_30_counts.fetch(path, 0),
-        last_90_days: last_90_counts.fetch(path, 0),
-      }
+    sql = %{
+      content_item.path AS path,
+      COUNT(*) FILTER (WHERE anonymous_contacts.created_at >= CURRENT_DATE - INTERVAL '7 days') AS last_7_days,
+      COUNT(*) FILTER (WHERE anonymous_contacts.created_at >= CURRENT_DATE - INTERVAL '30 days') AS last_30_days,
+      COUNT(*) AS last_90_days
     }
-      .compact
-      .sort_by { _1[order_by.to_sym] }
-      .tap { |result| result.reverse! unless order_by == "path" }
-  end
-
-  def self.count_in_last_n_days(last_n_days, relation:)
     (relation || all)
-      .joins(:content_item)
+      .joins("INNER JOIN content_items AS content_item ON content_item.id = anonymous_contacts.content_item_id")
       .created_between_days(
-        Time.zone.today - last_n_days.days,
+        Time.zone.today - 90.days,
         Time.zone.yesterday,
       )
       .group("content_item.path")
-      .count
+      .order(order_by) # sanitised by .show method of DocumentTypesController and OrganisationsController
+      .pluck(Arel.sql(sql))
+      .map { |result| Hash[%i[path last_7_days last_30_days last_90_days].zip(result)] }
+      .tap { |result| result.reverse! unless order_by == "path" }
   end
-  private_class_method :count_in_last_n_days
 
   def url
     Plek.new.website_root + (path || "")

--- a/db/migrate/20260615132016_add_indexes_for_summary.rb
+++ b/db/migrate/20260615132016_add_indexes_for_summary.rb
@@ -1,0 +1,6 @@
+class AddIndexesForSummary < ActiveRecord::Migration[8.1]
+  def change
+    add_index :content_items_organisations, %i[organisation_id content_item_id], name: :index_organisations_content_items, unique: true
+    add_index :organisations, %i[slug id], name: :index_organisations_on_slug_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2019_01_30_105818) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_132016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2019_01_30_105818) do
     t.integer "content_item_id"
     t.integer "organisation_id"
     t.index ["content_item_id", "organisation_id"], name: "index_content_items_organisations_unique", unique: true
+    t.index ["organisation_id", "content_item_id"], name: "index_organisations_content_items", unique: true
     t.index ["organisation_id"], name: "index_content_items_organisations_on_organisation_id"
   end
 
@@ -91,6 +92,7 @@ ActiveRecord::Schema[8.1].define(version: 2019_01_30_105818) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "web_url", limit: 255, null: false
     t.index ["content_id"], name: "index_organisations_on_content_id", unique: true
+    t.index ["slug", "id"], name: "index_organisations_on_slug_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
When a query has to summarise a lot of feedback into 7-day, 30-day and 90-day ranges, sometimes the web page load of the support app times out.

Example: /anonymous_feedback/organisations/hm-revenue-customs

This might be avoided by querying more efficiently. Tests on a laptop suggest that the query times can be reduced to about a sixth (from ~180ms to ~30ms, reloading the page many times in succession so that the database is 'warm'). This is achieved by executing a single query to summarise all three ranges at once, and adding two new indexes.

* `CREATE INDEX ON organisations(slug, id);`
* `CREATE INDEX ON content_items_organisations(organisation_id, content_item_id);`

The existing index `anonymous_contacts(content_item_id, created_at)` is also used by the new query.

These have to be coded as SQL, because ActiveRecord has no DSL for FILTER statements, so these have to be coded as literal SQL. The statements are used to count the number of items of feedback in each range.

A typical query plan is as follows. All four scans are index scans. Three of the four are index-only scans.

```
 GroupAggregate  (cost=1235.22..1236.53 rows=35 width=60) (actual time=94.791..95.645 rows=796 loops=1)
   Group Key: ci.path
   ->  Sort  (cost=1235.22..1235.31 rows=35 width=44) (actual time=94.778..94.892 rows=3443 loops=1)
         Sort Key: ci.path
         Sort Method: quicksort  Memory: 333kB
         ->  Nested Loop  (cost=1.69..1234.32 rows=35 width=44) (actual time=0.162..92.073 rows=3443 loops=1)
               ->  Nested Loop  (cost=1.27..1090.86 rows=35 width=16) (actual time=0.132..83.940 rows=3443 loops=1)
                     ->  Nested Loop  (cost=0.70..81.80 rows=332 width=4) (actual time=0.041..8.225 rows=64342 loops=1)
                           ->  Index Only Scan using organisations_slug_id_idx on organisations o  (cost=0.28..4.29 rows=1 width=4) (actual time=0.031..0.032 rows=1 loops=1)
                                 Index Cond: (slug = 'hm-revenue-customs'::text)
                                 Heap Fetches: 0
                           ->  Index Only Scan using content_items_organisations_organisation_id_content_item_id_idx on content_items_organisations cio  (cost=0.42..65.32 rows=1218 width=8) (actual time=0.005..4.544 rows=64342 loops=1)
                                 Index Cond: (organisation_id = o.id)
                                 Heap Fetches: 0
                     ->  Index Only Scan using index_anonymous_contacts_on_content_item_id_and_created_at on anonymous_contacts ac  (cost=0.57..2.92 rows=12 width=12) (actual time=0.001..0.001 rows=0 loops=64342)
                           Index Cond: ((content_item_id = cio.content_item_id) AND (created_at >= (CURRENT_DATE - '90 days'::interval)))
                           Heap Fetches: 0
               ->  Index Scan using content_items_pkey on content_items ci  (cost=0.42..4.10 rows=1 width=40) (actual time=0.002..0.002 rows=1 loops=3443)
                     Index Cond: (id = cio.content_item_id)
```

This can be profiled by adding to the `support-api` Gemfile (not the `support` one) in the development group, and then appending `?pp=flamegraph` to a URL, such as http://support.dev.gov.uk/anonymous_feedback/organisations/hm-revenue-customs?pp=flamegraph

```
  gem "rack-mini-profiler"
  gem "stackprof"
```

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
